### PR TITLE
Levenshtein: change how ratio is computed

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/Levenshtein.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/Levenshtein.scala
@@ -13,7 +13,17 @@ object Levenshtein {
       else None // Don't return candidate when difference is large.
     }
     val result = candidatesWithRatio.sortBy(_._2).headOption.map(_._1)
-    result
+    result.orElse(prefixCandidate(query, candidates))
+  }
+
+  private def prefixCandidate(
+      query: String,
+      candidates: Seq[String]
+  ): Option[String] = {
+    val prefixCandidates = candidates.flatMap { candidate =>
+      if (candidate.startsWith(query)) Some(candidate) else None
+    }
+    Option(prefixCandidates).filter(_.length == 1).map(_.head)
   }
 
   /** Levenshtein distance. Implementation based on Wikipedia's algorithm. */

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/Levenshtein.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/Levenshtein.scala
@@ -7,10 +7,8 @@ object Levenshtein {
       candidates: Seq[String]
   ): Option[String] = {
     val candidatesWithRatio = candidates.flatMap { candidate =>
-      val minDifference = math.abs(query.length() - candidate.length())
-      val difference = distance(candidate)(query).toDouble - minDifference
-      val ratio = difference.toDouble /
-        math.min(query.length(), candidate.length())
+      val levDist = distance(candidate)(query).toDouble
+      val ratio = levDist / math.max(query.length(), candidate.length())
       if (ratio < 0.4) Some((candidate, ratio))
       else None // Don't return candidate when difference is large.
     }

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/Levenshtein.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/Levenshtein.scala
@@ -6,18 +6,16 @@ object Levenshtein {
       query: String,
       candidates: Seq[String]
   ): Option[String] = {
-    if (candidates.isEmpty) {
-      None
-    } else {
-      val candidate = candidates.sortBy(distance(query)).head
-      val maxLength = query.length() + candidate.length()
+    val candidatesWithRatio = candidates.flatMap { candidate =>
       val minDifference = math.abs(query.length() - candidate.length())
       val difference = distance(candidate)(query).toDouble - minDifference
       val ratio = difference.toDouble /
         math.min(query.length(), candidate.length())
-      if (ratio < 0.4) Some(candidate)
+      if (ratio < 0.4) Some((candidate, ratio))
       else None // Don't return candidate when difference is large.
     }
+    val result = candidatesWithRatio.sortBy(_._2).headOption.map(_._1)
+    result
   }
 
   /** Levenshtein distance. Implementation based on Wikipedia's algorithm. */

--- a/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/CliParserSuite.scala
+++ b/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/CliParserSuite.scala
@@ -295,7 +295,7 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decoding",
     "--decoding" :: "10" :: Nil,
     """|found argument '--decoding' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--encoding'?
+       |	Did you mean '--in'?
        |""".stripMargin
   )
 
@@ -303,7 +303,7 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decodung",
     "--decodung" :: "10" :: Nil,
     """|found argument '--decodung' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--encoding'?
+       |	Did you mean '--conf'?
        |""".stripMargin
   )
 
@@ -311,7 +311,7 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decodingg",
     "--decodingg" :: "10" :: Nil,
     """|found argument '--decodingg' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--encoding'?
+       |	Did you mean '--in'?
        |""".stripMargin
   )
 
@@ -319,7 +319,7 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decoddung",
     "--decoddung" :: "10" :: Nil,
     """|found argument '--decoddung' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--encoding'?
+       |	Did you mean '--conf'?
        |""".stripMargin
   )
 
@@ -327,7 +327,7 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decodding1",
     "--decodding1" :: "10" :: Nil,
     """|found argument '--decodding1' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--encoding'?
+       |	Did you mean '--in'?
        |""".stripMargin
   )
 
@@ -335,6 +335,7 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decodunk",
     "--decodunk" :: "10" :: Nil,
     """|found argument '--decodunk' which wasn't expected, or isn't valid in this context.
+       |	Did you mean '--conf'?
        |""".stripMargin
   )
 

--- a/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/CliParserSuite.scala
+++ b/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/CliParserSuite.scala
@@ -291,4 +291,51 @@ class CliParserSuite extends BaseCliParserSuite {
        |""".stripMargin
   )
 
+  checkError(
+    "match decoding",
+    "--decoding" :: "10" :: Nil,
+    """|found argument '--decoding' which wasn't expected, or isn't valid in this context.
+       |	Did you mean '--encoding'?
+       |""".stripMargin
+  )
+
+  checkError(
+    "match decodung",
+    "--decodung" :: "10" :: Nil,
+    """|found argument '--decodung' which wasn't expected, or isn't valid in this context.
+       |	Did you mean '--encoding'?
+       |""".stripMargin
+  )
+
+  checkError(
+    "match decodingg",
+    "--decodingg" :: "10" :: Nil,
+    """|found argument '--decodingg' which wasn't expected, or isn't valid in this context.
+       |	Did you mean '--encoding'?
+       |""".stripMargin
+  )
+
+  checkError(
+    "match decoddung",
+    "--decoddung" :: "10" :: Nil,
+    """|found argument '--decoddung' which wasn't expected, or isn't valid in this context.
+       |	Did you mean '--encoding'?
+       |""".stripMargin
+  )
+
+  checkError(
+    "match decodding1",
+    "--decodding1" :: "10" :: Nil,
+    """|found argument '--decodding1' which wasn't expected, or isn't valid in this context.
+       |	Did you mean '--encoding'?
+       |""".stripMargin
+  )
+
+  checkError(
+    "match decodunk",
+    "--decodunk" :: "10" :: Nil,
+    """|found argument '--decodunk' which wasn't expected, or isn't valid in this context.
+       |""".stripMargin
+  )
+
 }

--- a/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/CliParserSuite.scala
+++ b/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/CliParserSuite.scala
@@ -287,7 +287,6 @@ class CliParserSuite extends BaseCliParserSuite {
     "skip hidden",
     "--hidden1" :: "10" :: Nil,
     """|found argument '--hidden1' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--in'?
        |""".stripMargin
   )
 
@@ -295,7 +294,7 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decoding",
     "--decoding" :: "10" :: Nil,
     """|found argument '--decoding' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--in'?
+       |	Did you mean '--encoding'?
        |""".stripMargin
   )
 
@@ -303,7 +302,7 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decodung",
     "--decodung" :: "10" :: Nil,
     """|found argument '--decodung' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--conf'?
+       |	Did you mean '--encoding'?
        |""".stripMargin
   )
 
@@ -311,7 +310,7 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decodingg",
     "--decodingg" :: "10" :: Nil,
     """|found argument '--decodingg' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--in'?
+       |	Did you mean '--encoding'?
        |""".stripMargin
   )
 
@@ -319,7 +318,6 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decoddung",
     "--decoddung" :: "10" :: Nil,
     """|found argument '--decoddung' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--conf'?
        |""".stripMargin
   )
 
@@ -327,7 +325,6 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decodding1",
     "--decodding1" :: "10" :: Nil,
     """|found argument '--decodding1' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--in'?
        |""".stripMargin
   )
 
@@ -335,7 +332,6 @@ class CliParserSuite extends BaseCliParserSuite {
     "match decodunk",
     "--decodunk" :: "10" :: Nil,
     """|found argument '--decodunk' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--conf'?
        |""".stripMargin
   )
 

--- a/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/SubcommandSuite.scala
+++ b/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/SubcommandSuite.scala
@@ -160,6 +160,7 @@ class SubcommandSuite extends FunSuite {
   checkError(
     List("test", "--max=40"),
     """|error: found argument '--max' which wasn't expected, or isn't valid in this context.
+       |	Did you mean '--max-count'?
        |""".stripMargin
   )
   checkError(

--- a/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/SubcommandSuite.scala
+++ b/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/SubcommandSuite.scala
@@ -160,7 +160,6 @@ class SubcommandSuite extends FunSuite {
   checkError(
     List("test", "--max=40"),
     """|error: found argument '--max' which wasn't expected, or isn't valid in this context.
-       |	Did you mean '--max-count'?
        |""".stripMargin
   )
   checkError(


### PR DESCRIPTION
Don't subtract the length difference from distance, as that leads to low numbers (frequently, zero) on pairs which are quite dissimilar. Instead, divide by the length of the longer of the two.

Fixes #78.