### PR TITLE
fix typesafeconfig HOCON include

### DIFF
--- a/metaconfig-tests/jvm/src/test/scala/metaconfig/sconfig/SConfig2ClassSuite.scala
+++ b/metaconfig-tests/jvm/src/test/scala/metaconfig/sconfig/SConfig2ClassSuite.scala
@@ -3,7 +3,7 @@ package metaconfig.sconfig
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
-import metaconfig.Conf
+import metaconfig.{Conf, Position}
 
 class SConfig2ClassSuite extends munit.FunSuite {
   test("basic") {
@@ -49,5 +49,55 @@ class SConfig2ClassSuite extends munit.FunSuite {
       )
     )
     assertEquals(obtained, expected)
+  }
+
+  test("include") {
+    val dir = Files.createTempDirectory("include")
+
+    val main = dir.resolve("main.conf")
+    Files.write(
+      main,
+      """|a = [ 1 ]
+         |include "included.conf"
+         |c = bar
+         |""".stripMargin.getBytes()
+    )
+
+    val included = dir.resolve("included.conf")
+    Files.write(
+      included,
+      s"""|a = $${a} [
+          |  "2",
+          |  3,
+          |  true
+          |]
+          |b = foo
+          |""".stripMargin.getBytes()
+    )
+
+    val obtained = SConfig2Class.gimmeConfFromFile(main.toFile).get
+    val expected: Conf = Conf.Obj(
+      "a" -> Conf.Lst(
+        Conf.Num(1),
+        Conf.Str("2"),
+        Conf.Num(3),
+        Conf.Bool(true)
+      ),
+      "b" -> Conf.Str("foo"),
+      "c" -> Conf.Str("bar")
+    )
+    assertEquals(obtained, expected)
+
+    val obtainedObj = obtained.asInstanceOf[Conf.Obj]
+
+    // declaration spread between main file and included file -> unknown position
+    val aPos = obtainedObj.field("a").get.pos
+    assertEquals(aPos, Position.None: Position)
+
+    val bPos = obtainedObj.field("b").get.pos
+    assertEquals(bPos.lineContent, "b = foo")
+
+    val cPos = obtainedObj.field("c").get.pos
+    assertEquals(cPos.lineContent, "c = bar")
   }
 }

--- a/metaconfig-tests/jvm/src/test/scala/metaconfig/typesafeconfig/TypesafeConfig2ClassSuite.scala
+++ b/metaconfig-tests/jvm/src/test/scala/metaconfig/typesafeconfig/TypesafeConfig2ClassSuite.scala
@@ -3,7 +3,7 @@ package metaconfig.typesafeconfig
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
-import metaconfig.Conf
+import metaconfig.{Conf, Position}
 
 class TypesafeConfig2ClassSuite extends munit.FunSuite {
   test("basic") {
@@ -49,5 +49,55 @@ class TypesafeConfig2ClassSuite extends munit.FunSuite {
       )
     )
     assertEquals(obtained, expected)
+  }
+
+  test("include") {
+    val dir = Files.createTempDirectory("include")
+
+    val main = dir.resolve("main.conf")
+    Files.write(
+      main,
+      """|a = [ 1 ]
+         |include "included.conf"
+         |c = bar
+         |""".stripMargin.getBytes()
+    )
+
+    val included = dir.resolve("included.conf")
+    Files.write(
+      included,
+      s"""|a = $${a} [
+          |  "2",
+          |  3,
+          |  true
+          |]
+          |b = foo
+          |""".stripMargin.getBytes()
+    )
+
+    val obtained = TypesafeConfig2Class.gimmeConfFromFile(main.toFile).get
+    val expected: Conf = Conf.Obj(
+      "a" -> Conf.Lst(
+        Conf.Num(1),
+        Conf.Str("2"),
+        Conf.Num(3),
+        Conf.Bool(true)
+      ),
+      "b" -> Conf.Str("foo"),
+      "c" -> Conf.Str("bar")
+    )
+    assertEquals(obtained, expected)
+
+    val obtainedObj = obtained.asInstanceOf[Conf.Obj]
+
+    // declaration spread between main file and included file -> unknown position
+    val aPos = obtainedObj.field("a").get.pos
+    assertEquals(aPos, Position.None: Position)
+
+    val bPos = obtainedObj.field("b").get.pos
+    assertEquals(bPos.lineContent, "b = foo")
+
+    val cPos = obtainedObj.field("c").get.pos
+    assertEquals(cPos.lineContent, "c = bar")
   }
 }


### PR DESCRIPTION
Originally reported in https://github.com/scalacenter/scalafix/issues/1414. I was surprised it was not first reported through Scalafmt, but it looks like the bump there was [recent](https://github.com/scalameta/scalafmt/commit/ba631feb4e80c7024b63449aa6e8acec101e2bf6), so no release was cut with the regression.

Since df7731d `TypesafeConfig2Class` was always looking up positions from the main input, causing incorrect mappings at best, or parsing failures when a key was defined in an included file larger than the main one (1) or when a key was defined across files (2).

(1)
```
java.lang.IllegalArgumentException: 8 is not a valid line number, allowed [0..1]
 at metaconfig.Input.lineToOffset(Input.scala:36)
 at metaconfig.typesafeconfig.Typesafe...(TypesafeConfig2Class.scala:85)
```

(2) 
```
java.lang.IllegalArgumentException: -2 is not a valid line number, allowed [0..3]
 at metaconfig.Input.lineToOffset(Input.scala:36)
 at metaconfig.typesafeconfig.Typesafe...(TypesafeConfig2Class.scala:85)
```