### PR TITLE
reduce risk of NoSuchMethodError when runtime version <0.9.11

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/Macros.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/Macros.scala
@@ -284,7 +284,11 @@ class Macros(val c: blackbox.Context) {
         annot.tree
     }
     val result =
-      q"new ${weakTypeOf[Surface[T]]}($args, _root_.scala.List.apply(..$classAnnotations))"
+      if (classAnnotations.isEmpty) {
+        q"new ${weakTypeOf[Surface[T]]}($args)"
+      } else {
+        q"new ${weakTypeOf[Surface[T]]}($args, _root_.scala.List.apply(..$classAnnotations))"
+      }
     c.untypecheck(result)
   }
 


### PR DESCRIPTION
Improve forward-compatibility of df7731d

```
java.lang.NoSuchMethodError: 'void metaconfig.generic.Surface.<init>(scala.collection.immutable.List, scala.collection.immutable.List)'
  at scalafix.internal.scaluzzi.DisableConfig$.<init>(DisableConfig.scala:162)
```

Reported/discussion in https://gitter.im/scalacenter/scalafix?at=60b41af5688a2624b8bf52c0