### PR TITLE
ConfDecoderEx: infer surface if Settings missing

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfCodecExT.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfCodecExT.scala
@@ -1,7 +1,5 @@
 package metaconfig
 
-import metaconfig.generic.Settings
-
 class ConfCodecExT[S, A](
     encoder: ConfEncoder[A],
     decoder: ConfDecoderExT[S, A]
@@ -13,13 +11,6 @@ class ConfCodecExT[S, A](
 
   def bimap[B](in: B => A, out: A => B): ConfCodecExT[S, B] =
     new ConfCodecExT[S, B](encoder.contramap(in), decoder.map(out))
-
-  def noTypos(implicit settings: Settings[A]): ConfCodecExT[S, A] = {
-    val noTyposDecoder = decoder.noTypos
-    if (noTyposDecoder eq decoder) this
-    else new ConfCodecExT(encoder, noTyposDecoder)
-  }
-
 }
 
 object ConfCodecExT {

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoderExT.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoderExT.scala
@@ -6,8 +6,6 @@ import scala.reflect.ClassTag
 import java.nio.file.Path
 import java.nio.file.Paths
 
-import metaconfig.internal.NoTyposDecoderEx
-
 trait ConfDecoderExT[-S, A] {
 
   def read(state: Option[S], conf: Conf): Configured[A]
@@ -177,10 +175,6 @@ object ConfDecoderExT {
         self.read(state, conf).recoverWith { x =>
           other.read(state, conf).recoverWith(x.combine)
         }
-
-    def noTypos(implicit settings: generic.Settings[A]): ConfDecoderExT[S, A] =
-      if (self.isInstanceOf[NoTyposDecoderEx[_, _]]) self
-      else new NoTyposDecoderEx[S, A](self)
 
   }
 

--- a/metaconfig-core/shared/src/main/scala/metaconfig/generic/package.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/generic/package.scala
@@ -12,8 +12,8 @@ package object generic {
   def deriveCodec[T](default: T): ConfCodec[T] =
     macro metaconfig.internal.Macros.deriveConfCodecImpl[T]
 
-  def deriveDecoderEx[T](default: T): ConfDecoderEx[T] =
+  def deriveDecoderEx[T](default: T, typosAllowed: Boolean): ConfDecoderEx[T] =
     macro metaconfig.internal.Macros.deriveConfDecoderExImpl[T]
-  def deriveCodecEx[T](default: T): ConfCodecEx[T] =
+  def deriveCodecEx[T](default: T, typosAllowed: Boolean): ConfCodecEx[T] =
     macro metaconfig.internal.Macros.deriveConfCodecExImpl[T]
 }

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/NoTyposDecoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/NoTyposDecoder.scala
@@ -2,7 +2,6 @@ package metaconfig.internal
 
 import metaconfig.Conf
 import metaconfig.ConfDecoder
-import metaconfig.ConfDecoderExT
 import metaconfig.ConfError
 import metaconfig.Configured
 import metaconfig.generic.Settings
@@ -13,7 +12,7 @@ object NoTyposDecoder {
     if (underlying.isInstanceOf[NoTyposDecoder[_]]) underlying
     else new NoTyposDecoder[A](underlying)
 
-  private[internal] def checkTypos[A](conf: Conf, otherwise: => Configured[A])(
+  def checkTypos[A](conf: Conf, otherwise: => Configured[A])(
       implicit ev: Settings[A]
   ): Configured[A] =
     ConfDecoder.readWithPartial("Object") {
@@ -35,13 +34,5 @@ class NoTyposDecoder[A: Settings](underlying: ConfDecoder[A])
 
   override def read(conf: Conf): Configured[A] =
     NoTyposDecoder.checkTypos(conf, underlying.read(conf))
-
-}
-
-class NoTyposDecoderEx[S, A: Settings](underlying: ConfDecoderExT[S, A])
-    extends ConfDecoderExT[S, A] {
-
-  override def read(state: Option[S], conf: Conf): Configured[A] =
-    NoTyposDecoder.checkTypos(conf, underlying.read(state, conf))
 
 }

--- a/metaconfig-tests/shared/src/main/scala/metaconfig/AllTheAnnotations.scala
+++ b/metaconfig-tests/shared/src/main/scala/metaconfig/AllTheAnnotations.scala
@@ -30,7 +30,7 @@ object AllTheAnnotations {
   implicit lazy val decoder: ConfDecoder[AllTheAnnotations] =
     generic.deriveDecoder[AllTheAnnotations](AllTheAnnotations()).noTypos
   implicit lazy val decoderEx: ConfDecoderEx[AllTheAnnotations] =
-    generic.deriveDecoderEx[AllTheAnnotations](AllTheAnnotations()).noTypos
+    generic.deriveDecoderEx[AllTheAnnotations](AllTheAnnotations(), false)
   implicit val encoder: ConfEncoder[AllTheAnnotations] =
     generic.deriveEncoder[AllTheAnnotations]
 }
@@ -41,7 +41,7 @@ object OneParam {
   implicit val codec: ConfCodec[OneParam] =
     generic.deriveCodec[OneParam](OneParam())
   implicit val decoderEx: ConfDecoderEx[OneParam] =
-    generic.deriveDecoderEx[OneParam](OneParam()).noTypos
+    generic.deriveDecoderEx[OneParam](OneParam(), false)
 }
 
 case class HasOption(b: Option[Int] = None)
@@ -50,7 +50,7 @@ object HasOption {
   implicit val decoder: ConfDecoder[HasOption] =
     generic.deriveDecoder[HasOption](HasOption())
   implicit val decoderEx: ConfDecoderEx[HasOption] =
-    generic.deriveDecoderEx[HasOption](HasOption())
+    generic.deriveDecoderEx[HasOption](HasOption(), true)
   implicit val encoder: ConfEncoder[HasOption] =
     generic.deriveEncoder[HasOption]
 }
@@ -78,7 +78,7 @@ object IsIterable {
   implicit val decoder: ConfDecoder[IsIterable] =
     generic.deriveDecoder[IsIterable](IsIterable())
   implicit val decoderEx: ConfDecoderEx[IsIterable] =
-    generic.deriveDecoderEx[IsIterable](IsIterable()).noTypos
+    generic.deriveDecoderEx[IsIterable](IsIterable(), false)
   implicit val encoder: ConfEncoder[IsIterable] =
     generic.deriveEncoder[IsIterable]
 }
@@ -93,7 +93,7 @@ object Nested2 {
   implicit val codec: ConfCodec[Nested2] =
     generic.deriveCodec[Nested2](Nested2())
   implicit val decoderEx: ConfDecoderEx[Nested2] =
-    generic.deriveDecoderEx[Nested2](Nested2()).noTypos
+    generic.deriveDecoderEx[Nested2](Nested2(), false)
 }
 
 case class Nested3(
@@ -105,7 +105,7 @@ object Nested3 {
   implicit val codec: ConfCodec[Nested3] =
     generic.deriveCodec[Nested3](Nested3())
   implicit val decoderEx: ConfDecoderEx[Nested3] =
-    generic.deriveDecoderEx[Nested3](Nested3()).noTypos
+    generic.deriveDecoderEx[Nested3](Nested3(), false)
 }
 
 case class Nested(
@@ -119,5 +119,5 @@ object Nested {
   implicit val surface: Surface[Nested] = generic.deriveSurface[Nested]
   implicit val codec: ConfCodec[Nested] = generic.deriveCodec[Nested](Nested())
   implicit val decoderEx: ConfDecoderEx[Nested] =
-    generic.deriveDecoderEx[Nested](Nested()).noTypos
+    generic.deriveDecoderEx[Nested](Nested(), false)
 }

--- a/metaconfig-tests/shared/src/main/scala/metaconfig/AllTheAnnotations.scala
+++ b/metaconfig-tests/shared/src/main/scala/metaconfig/AllTheAnnotations.scala
@@ -37,7 +37,6 @@ object AllTheAnnotations {
 
 case class OneParam(param: Int = 82)
 object OneParam {
-  implicit val surface: Surface[OneParam] = generic.deriveSurface[OneParam]
   implicit val codec: ConfCodec[OneParam] =
     generic.deriveCodec[OneParam](OneParam())
   implicit val decoderEx: ConfDecoderEx[OneParam] =
@@ -46,7 +45,6 @@ object OneParam {
 
 case class HasOption(b: Option[Int] = None)
 object HasOption {
-  implicit val surface: Surface[HasOption] = generic.deriveSurface[HasOption]
   implicit val decoder: ConfDecoder[HasOption] =
     generic.deriveDecoder[HasOption](HasOption())
   implicit val decoderEx: ConfDecoderEx[HasOption] =
@@ -74,7 +72,6 @@ case class IsIterable(
     b: Iterable[String] = Iterable.empty
 )
 object IsIterable {
-  implicit val surface: Surface[IsIterable] = generic.deriveSurface[IsIterable]
   implicit val decoder: ConfDecoder[IsIterable] =
     generic.deriveDecoder[IsIterable](IsIterable())
   implicit val decoderEx: ConfDecoderEx[IsIterable] =
@@ -89,7 +86,6 @@ case class Nested2(
     c: Map[String, OneParam] = Map("k2" -> OneParam(2))
 )
 object Nested2 {
-  implicit val surface: Surface[Nested2] = generic.deriveSurface[Nested2]
   implicit val codec: ConfCodec[Nested2] =
     generic.deriveCodec[Nested2](Nested2())
   implicit val decoderEx: ConfDecoderEx[Nested2] =
@@ -101,7 +97,6 @@ case class Nested3(
     b: Nested2 = Nested2()
 )
 object Nested3 {
-  implicit val surface: Surface[Nested3] = generic.deriveSurface[Nested3]
   implicit val codec: ConfCodec[Nested3] =
     generic.deriveCodec[Nested3](Nested3())
   implicit val decoderEx: ConfDecoderEx[Nested3] =
@@ -116,7 +111,6 @@ case class Nested(
     e: Nested3 = Nested3()
 )
 object Nested {
-  implicit val surface: Surface[Nested] = generic.deriveSurface[Nested]
   implicit val codec: ConfCodec[Nested] = generic.deriveCodec[Nested](Nested())
   implicit val decoderEx: ConfDecoderEx[Nested] =
     generic.deriveDecoderEx[Nested](Nested(), false)

--- a/metaconfig-tests/shared/src/test/scala/metaconfig/DeriveConfDecoderExSuite.scala
+++ b/metaconfig-tests/shared/src/test/scala/metaconfig/DeriveConfDecoderExSuite.scala
@@ -102,7 +102,7 @@ class DeriveConfDecoderExSuite extends munit.FunSuite {
   }
 
   test("no param") {
-    val decoder = generic.deriveDecoderEx[NoParam](NoParam())
+    val decoder = generic.deriveDecoderEx[NoParam](NoParam(), true)
     val obtained = decoder.read(None, Obj("param" -> Num(2))).get
     val expected = NoParam()
     assert(obtained == expected)

--- a/metaconfig-tests/shared/src/test/scala/metaconfig/SettingsSuite.scala
+++ b/metaconfig-tests/shared/src/test/scala/metaconfig/SettingsSuite.scala
@@ -4,6 +4,7 @@ import metaconfig.annotation.Deprecated
 import metaconfig.annotation.DeprecatedName
 import metaconfig.annotation.ExtraName
 import metaconfig.generic.Settings
+import metaconfig.generic.Surface
 
 class SettingsSuite extends munit.FunSuite {
 
@@ -68,6 +69,9 @@ class SettingsSuite extends munit.FunSuite {
   }
 
   test("flat") {
+    implicit val surfaceNested2 = generic.deriveSurface[Nested2]
+    implicit val surfaceNested3 = generic.deriveSurface[Nested3]
+    implicit val surfaceNested = generic.deriveSurface[Nested]
     val flat = Settings[Nested]
       .flat(ConfEncoder[Nested].writeObj(Nested()))
       .map { case (s, c) => s"${s.name} $c" }


### PR DESCRIPTION
This allows users to skip defining the Surface explicitly.