### PR TITLE
Skip publishing mdoc due to currently incompatible pprint version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -218,6 +218,7 @@ lazy val docs = project
   .in(file("metaconfig-docs"))
   .settings(
     sharedSettings,
+    publish / skip := true,
     crossScalaVersions -= scala3,
     libraryDependencies ++= List(
       "org.scalameta" %%% "munit-scalacheck" % V.munit


### PR DESCRIPTION
It seems to have failed in https://github.com/scalameta/metaconfig/runs/4816747292?check_suite_focus=true

It would probably be good to shade the pprint version :/