### PR TITLE
sbt: upgrade to 1.6.2 to fix build

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2


### PR DESCRIPTION
Can't build with java 18 otherwise (sbt/sbt#6925).