### PR TITLE
Conf: refactor getNested to getNestedConf

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfDynamic.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfDynamic.scala
@@ -6,20 +6,7 @@ class ConfDynamic(val asConf: Configured[Conf]) extends Dynamic {
   def as[T](implicit ev: ConfDecoder[T]): Configured[T] =
     asConf.andThen(_.as[T])
   def selectDynamic(name: String): ConfDynamic = {
-    val result =
-      asConf.andThen {
-        case obj @ Conf.Obj(values) =>
-          values
-            .collectFirst {
-              case (`name`, value) =>
-                Configured.Ok(value)
-            }
-            .getOrElse(ConfError.missingField(obj, name).notOk)
-        case els =>
-          ConfError
-            .typeMismatch(s"Conf.Obj (with field $name)", els, name)
-            .notOk
-      }
+    val result = asConf.andThen(_.getConf(name))
     ConfDynamic(result)
   }
 }

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Input.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Input.scala
@@ -106,7 +106,12 @@ object Input {
     def parse(
         path: Option[Predef.String]
     )(implicit parser: MetaconfigParser): Configured[Conf] =
-      path.fold(parse)(x => ConfDynamic(parse).selectDynamic(x).asConf)
+      path.fold(parse)(x => parse.andThen(_.getConf(x)))
+
+    def parse(
+        path: Predef.String*
+    )(implicit parser: MetaconfigParser): Configured[Conf] =
+      parse.andThen(_.getNestedConf(path: _*))
 
   }
 

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/ConfGet.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/ConfGet.scala
@@ -45,23 +45,10 @@ object ConfGet {
     }
   }
 
-  @tailrec
   def getNested[T](conf: Conf, keys: String*)(
       implicit ev: ConfDecoder[T]
   ): Configured[T] =
-    keys.headOption match {
-      case None => ev.read(conf)
-      case Some(key) =>
-        conf match {
-          case obj: Conf.Obj =>
-            obj.values.collectFirst { case (`key`, v) => v } match {
-              case Some(v) => getNested(v, keys.tail: _*)
-              case _ => ConfError.missingField(obj, key).notOk
-            }
-          case _ =>
-            ConfError.typeMismatch(s"Conf.Obj with key '$key'", conf).notOk
-        }
-    }
+    conf.getNestedConf(keys: _*).andThen(ev.read)
 
   // Copy-pasted from scala.meta inputs because it's private.
   // TODO(olafur) expose utility in inputs to get offset from line


### PR DESCRIPTION
That way, we can read using both ConfDecoder and ConfDecoderExT. Follow-on to #169.