### PR TITLE
Update docs to compile on Scala 3

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,15 +37,18 @@ libraryDependencies += "com.geirsson" %% "metaconfig-typesafe-config" % "@VERSIO
 Next, write a case class for your user configuration.
 
 ```scala mdoc
+import metaconfig._
+import metaconfig.generic._
+
 case class HelloConfig(
   verbose: Boolean = false,
   name: String = "Susan"
 )
 object HelloConfig {
   lazy val default = HelloConfig()
-  implicit lazy val surface = metaconfig.generic.deriveSurface[HelloConfig]
-  implicit lazy val decoder = metaconfig.generic.deriveDecoder[HelloConfig](default)
-  implicit lazy val encoder = metaconfig.generic.deriveEncoder[HelloConfig]
+  implicit lazy val surface: Surface[HelloConfig] = deriveSurface[HelloConfig]
+  implicit lazy val decoder: ConfDecoder[HelloConfig] = deriveDecoder[HelloConfig](default)
+  implicit lazy val encoder: ConfEncoder[HelloConfig] = deriveEncoder[HelloConfig]
 }
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -234,7 +234,7 @@ automatically derive a `ConfEncoder[T]` instance for any case class with
 `generic.deriveEncoder`.
 
 ```scala mdoc
-implicit val encoder = generic.deriveEncoder[User]
+implicit val encoder: ConfEncoder[User] = generic.deriveEncoder[User]
 
 ConfEncoder[User].write(User("John", 42))
 ```
@@ -257,8 +257,8 @@ It's common to have a class that has both a `ConfDecoder[T]` and
 
 ```scala mdoc:silent
 case class Bijective(name: String)
-implicit val surface = generic.deriveSurface[Bijective]
-implicit val codec = generic.deriveCodec[Bijective](new Bijective("default"))
+implicit val surface: generic.Surface[Bijective] = generic.deriveSurface[Bijective]
+implicit val codec: ConfCodec[Bijective] = generic.deriveCodec[Bijective](new Bijective("default"))
 ```
 
 ```scala mdoc
@@ -429,8 +429,10 @@ case class EvolvingConfig(
     @DeprecatedName("goodName", "Use isGoodName instead", "1.0")
     isGoodName: Boolean
 )
-implicit val surface = generic.deriveSurface[EvolvingConfig]
-implicit val decoder = generic.deriveDecoder[EvolvingConfig](EvolvingConfig(true)).noTypos
+implicit val surface: generic.Surface[EvolvingConfig] =
+  generic.deriveSurface[EvolvingConfig]
+implicit val decoder: ConfDecoder[EvolvingConfig] =
+  generic.deriveDecoder[EvolvingConfig](EvolvingConfig(true)).noTypos
 ```
 
 ```scala mdoc
@@ -555,8 +557,8 @@ case class Home(
     @Description("Country description")
     country: String = "Iceland"
 )
-implicit val homeSurface = generic.deriveSurface[Home]
-implicit val homeEncoder = generic.deriveEncoder[Home]
+implicit val homeSurface: Surface[Home] = generic.deriveSurface[Home]
+implicit val homeEncoder: ConfEncoder[Home] = generic.deriveEncoder[Home]
 
 case class User(
     @Description("Name description")
@@ -565,8 +567,8 @@ case class User(
     age: Int = 42,
     home: Home = Home()
 )
-implicit val userSurface = generic.deriveSurface[User]
-implicit val userEncoder = generic.deriveEncoder[User]
+implicit val userSurface: Surface[User] = generic.deriveSurface[User]
+implicit val userEncoder: ConfEncoder[User] = generic.deriveEncoder[User]
 ```
 
 To generate html documentation, pass in a default value


### PR DESCRIPTION
Now the docs project is also enabled for Scala 3.
It means that all the examples in the docs need to compile with Scala 3