### PR TITLE
NoTyposDecoder: detect a Transformable and apply

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/Transformable.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/Transformable.scala
@@ -1,0 +1,6 @@
+package metaconfig.internal
+
+trait Transformable[A] { self: A =>
+  type SelfType = A
+  def transform(f: A => A): A
+}


### PR DESCRIPTION
NoTypos check should be performed last, so if there was another wrapper applied, let's switch them around.