### PR TITLE
Revise Input.File, sconfig parser to support JS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,11 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       val scalaMajor = if (isScala3.value) "scala-3" else "scala-2"
       baseDirectory.value / "shared" / "src" / "main" / scalaMajor
     },
-  ).dependsOn(pprint)
+  ).dependsOn(pprint).jsSettings(
+    sharedJSSettings,
+    libraryDependencies += smorg %%% "io" % "4.13.0" cross
+      CrossVersion.for3Use2_13,
+  )
 
 lazy val cli = crossProject(JVMPlatform, NativePlatform)
   .in(file("metaconfig-cli")).settings(
@@ -181,7 +185,7 @@ lazy val sconfig = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     ),
   ).platformsSettings(JSPlatform, NativePlatform)(
     libraryDependencies += "org.ekrich" %%% "sjavatime" % "1.3.0",
-  ).dependsOn(core)
+  ).jsSettings(sharedJSSettings).dependsOn(core)
 
 lazy val tests = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .in(file("metaconfig-tests")).disablePlugins(MimaPlugin).settings(
@@ -219,7 +223,7 @@ lazy val tests = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       )
     },
   ).jvmEnablePlugins(GraalVMNativeImagePlugin)
-  .jvmConfigure(_.dependsOn(typesafe, cli.jvm, sconfig.jvm)).dependsOn(core)
+  .jvmConfigure(_.dependsOn(typesafe, cli.jvm)).dependsOn(core, sconfig)
 
 lazy val docs = project.in(file("metaconfig-docs")).settings(
   sharedSettings,

--- a/metaconfig-core/js/src/main/scala/metaconfig/PlatformInput.scala
+++ b/metaconfig-core/js/src/main/scala/metaconfig/PlatformInput.scala
@@ -1,0 +1,15 @@
+package metaconfig
+
+import java.nio.file.Path
+
+import scala.meta.internal.io._
+
+private[metaconfig] object PlatformInput {
+
+  def readFile(path: String, charset: String): String = JSFs
+    .readFileSync(path, charset)
+
+  def readFile(path: Path, charset: String): String =
+    readFile(path.toString, charset)
+
+}

--- a/metaconfig-core/jvm/src/main/scala/metaconfig/PlatformInput.scala
+++ b/metaconfig-core/jvm/src/main/scala/metaconfig/PlatformInput.scala
@@ -1,0 +1,15 @@
+package metaconfig
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+private[metaconfig] object PlatformInput {
+
+  def readFile(path: String, charset: String): String =
+    readFile(Paths.get(path), charset)
+
+  def readFile(path: Path, charset: String): String =
+    new String(Files.readAllBytes(path), charset)
+
+}

--- a/metaconfig-core/native/src/main/scala/metaconfig/PlatformInput.scala
+++ b/metaconfig-core/native/src/main/scala/metaconfig/PlatformInput.scala
@@ -1,0 +1,15 @@
+package metaconfig
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+private[metaconfig] object PlatformInput {
+
+  def readFile(path: String, charset: String): String =
+    readFile(Paths.get(path), charset)
+
+  def readFile(path: Path, charset: String): String =
+    new String(Files.readAllBytes(path), charset)
+
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/Input.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/Input.scala
@@ -2,7 +2,6 @@ package metaconfig
 
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 import java.nio.file.Path
 
 import scala.collection.mutable
@@ -81,13 +80,9 @@ object Input {
   }
 
   final case class File(file: Path, charset: Charset)
-      extends Input(
-        file.toString,
-        new Predef.String(Files.readAllBytes(file), charset.name),
-      )
+      extends Input(file.toString, PlatformInput.readFile(file, charset.name()))
   object File {
-    def apply(file: java.io.File): Input = Input
-      .File(file.toPath, StandardCharsets.UTF_8)
+    def apply(file: java.io.File): Input = apply(file.toPath)
     def apply(path: Path): Input = Input.File(path, StandardCharsets.UTF_8)
   }
 

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/TermInfo.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/TermInfo.scala
@@ -3,7 +3,7 @@ package metaconfig.internal
 import java.nio.file.Files
 import java.nio.file.Paths
 
-import scala.util.control.NonFatal
+import scala.util.Try
 
 object TermInfo {
 
@@ -12,12 +12,9 @@ object TermInfo {
 
   def tputsColumns(fallback: Int = 80): Int = {
     import scala.sys.process._
-    val pathedTput =
-      if (Files.exists(Paths.get("/usr/bin/tput"))) "/usr/bin/tput" else "tput"
-    try {
-      val columns = Seq("sh", "-c", s"$pathedTput cols 2> /dev/tty").!!.trim
-        .toInt
-      columns.toInt
-    } catch { case NonFatal(_) => fallback }
+    val exists = Files.exists(Paths.get("/usr/bin/tput"))
+    val pathedTput = if (exists) "/usr/bin/tput" else "tput"
+    Try(Seq("sh", "-c", s"$pathedTput cols 2> /dev/tty").!!.trim.toInt)
+      .getOrElse(fallback)
   }
 }

--- a/metaconfig-sconfig/js/src/main/scala/metaconfig/sconfig/PlatformFileOps.scala
+++ b/metaconfig-sconfig/js/src/main/scala/metaconfig/sconfig/PlatformFileOps.scala
@@ -1,0 +1,11 @@
+package metaconfig.sconfig
+
+import metaconfig.Input
+
+import java.net.URL
+
+object PlatformFileOps {
+
+  def fromURL(url: URL): Option[Input] = None
+
+}

--- a/metaconfig-sconfig/jvm/src/main/scala/metaconfig/sconfig/PlatformFileOps.scala
+++ b/metaconfig-sconfig/jvm/src/main/scala/metaconfig/sconfig/PlatformFileOps.scala
@@ -1,0 +1,12 @@
+package metaconfig.sconfig
+
+import metaconfig.Input
+
+import java.net.URL
+import java.nio.file.Paths
+
+object PlatformFileOps {
+
+  def fromURL(url: URL): Option[Input] = Some(Input.File(Paths.get(url.toURI)))
+
+}

--- a/metaconfig-sconfig/native/src/main/scala/metaconfig/sconfig/PlatformFileOps.scala
+++ b/metaconfig-sconfig/native/src/main/scala/metaconfig/sconfig/PlatformFileOps.scala
@@ -1,0 +1,12 @@
+package metaconfig.sconfig
+
+import metaconfig.Input
+
+import java.net.URL
+import java.nio.file.Paths
+
+object PlatformFileOps {
+
+  def fromURL(url: URL): Option[Input] = Some(Input.File(Paths.get(url.toURI)))
+
+}

--- a/metaconfig-sconfig/shared/src/main/scala/metaconfig/sconfig/package.scala
+++ b/metaconfig-sconfig/shared/src/main/scala/metaconfig/sconfig/package.scala
@@ -1,8 +1,12 @@
 package metaconfig
 
+import org.ekrich.config.ConfigFactory
+
 package object sconfig {
-  implicit val sConfigMetaconfigParser: MetaconfigParser = _ match {
-    case Input.File(path, _) => SConfig2Class.gimmeConfFromFile(path.toFile)
-    case els => SConfig2Class.gimmeConfFromString(new String(els.chars))
+  implicit val sConfigMetaconfigParser: MetaconfigParser = (input: Input) => {
+    // even if input is Input.File, let's not read it again and just parse as a string
+    // also, for JS, ConfigFactory emulates java.io.File but all methods are unimplemented
+    def config = ConfigFactory.parseString(input.text)
+    SConfig2Class.gimmeSafeConf(config, Some(input))
   }
 }

--- a/metaconfig-tests/shared/src/test/resources/metaconfig/input_test
+++ b/metaconfig-tests/shared/src/test/resources/metaconfig/input_test
@@ -1,0 +1,9 @@
+version = "1.2.3"
+
+newlines {
+  source = fold
+  configStyle {
+    callSite.preset = none
+    defnSite.force = true
+  }
+}

--- a/metaconfig-tests/shared/src/test/scala/metaconfig/sconfig/InputSuite.scala
+++ b/metaconfig-tests/shared/src/test/scala/metaconfig/sconfig/InputSuite.scala
@@ -1,0 +1,56 @@
+package metaconfig.sconfig
+
+import metaconfig.Conf
+import metaconfig.Configured
+import metaconfig.Input
+import metaconfig.PlatformInput
+
+import java.nio.file.Paths
+
+import munit.FunSuite
+
+class InputSuite extends FunSuite {
+
+  private val confPath = Paths
+    .get("metaconfig-tests/shared/src/test/resources/metaconfig/input_test")
+  private val confStr =
+    """|version = "1.2.3"
+       |
+       |newlines {
+       |  source = fold
+       |  configStyle {
+       |    callSite.preset = none
+       |    defnSite.force = true
+       |  }
+       |}
+       |""".stripMargin
+  private val confObj = Conf.Obj(
+    "newlines" -> Conf.Obj(
+      "source" -> Conf.Str("fold"),
+      "configStyle" -> Conf.Obj(
+        "callSite" -> Conf.Obj("preset" -> Conf.Str("none")),
+        "defnSite" -> Conf.Obj("force" -> Conf.Bool(true)),
+      ),
+    ),
+    "version" -> Conf.Str("1.2.3"),
+  )
+
+  test("PlatformInput.readFile") {
+    assertEquals(PlatformInput.readFile(confPath, "utf-8"), confStr)
+  }
+
+  test("SConfig2Class.gimmeConfFromString") {
+    assertEquals(
+      SConfig2Class.gimmeConfFromString(confStr),
+      Configured.Ok(confObj),
+    )
+  }
+
+  test("sConfigMetaconfigParser.fromInput") {
+    assertEquals(
+      sConfigMetaconfigParser.fromInput(Input.File(confPath)),
+      Configured.Ok(confObj),
+    )
+  }
+
+}


### PR DESCRIPTION
JS does not support java.io.File nor java.nio.file.Path, so this part of the functionality didn't work. Let's use the emulation added in org.scalameta.io package to accomplish that.