### PR TITLE
ConfDecoderXxx: add method to apply config updates

### DIFF
--- a/metaconfig-core/shared/src/main/scala-2/metaconfig/internal/Macros.scala
+++ b/metaconfig-core/shared/src/main/scala-2/metaconfig/internal/Macros.scala
@@ -98,6 +98,12 @@ class Macros(val c: blackbox.Context) {
     val product = params.foldLeft(next(head)) { case (accum, param) =>
       q"$accum.product(${next(param)})"
     }
+    val converted = (head :: params).foldLeft[Tree](q"conf") {
+      case (accum, param) =>
+        val P = param.info.resultType
+        val name = param.name.decodedName.toString
+        q"_root_.metaconfig.Conf.convert[$P]($accum, settings.unsafeGet($name))"
+    }
     val tupleExtract = 1.to(params.length)
       .foldLeft(q"t": Tree) { case (accum, _) => q"$accum._1" }
     var curr = tupleExtract
@@ -121,6 +127,13 @@ class Macros(val c: blackbox.Context) {
           val settings = $settings
           val tmp = $default
           $product.map { t => $ctor }
+        }
+
+        override def convert(
+          conf: _root_.metaconfig.Conf
+        ): _root_.metaconfig.Conf = {
+          val settings = $settings
+          $converted
         }
       }
     """
@@ -163,6 +176,12 @@ class Macros(val c: blackbox.Context) {
     val product = params.foldLeft(next(head)) { case (accum, param) =>
       q"$accum.product(${next(param)})"
     }
+    val converted = (head :: params).foldLeft[Tree](q"conf") {
+      case (accum, param) =>
+        val P = param.info.resultType
+        val name = param.name.decodedName.toString
+        q"Conf.convertEx[$P]($accum, settings.unsafeGet($name))"
+    }
     val tupleExtract = 1.to(params.length)
       .foldLeft(q"t": Tree) { case (accum, _) => q"$accum._1" }
     var curr = tupleExtract
@@ -187,6 +206,13 @@ class Macros(val c: blackbox.Context) {
           val settings = $settings
           val tmp = state.getOrElse($default)
           $product.map { t => $ctor }
+        }
+
+        override def convert(
+          conf: _root_.metaconfig.Conf
+        ): _root_.metaconfig.Conf = {
+          val settings = $settings
+          $converted
         }
       }
     """

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfCodec.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfCodec.scala
@@ -6,6 +6,7 @@ trait ConfCodec[A] extends ConfDecoder[A] with ConfEncoder[A] { self =>
   def bimap[B](in: B => A, out: A => B): ConfCodec[B] = new ConfCodec[B] {
     override def write(value: B): Conf = self.write(in(value))
     override def read(conf: Conf): Configured[B] = self.read(conf).map(out)
+    override def convert(conf: Conf): Conf = self.convert(conf)
   }
 }
 
@@ -18,6 +19,7 @@ object ConfCodec {
   ) extends ConfCodec[A] {
     override def write(value: A): Conf = encoder.write(value)
     override def read(conf: Conf): Configured[A] = decoder.read(conf)
+    override def convert(conf: Conf): Conf = decoder.convert(conf)
 
     private[metaconfig] def getPair(): (ConfEncoder[A], ConfDecoder[A]) =
       (encoder, decoder)

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfCodecExT.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfCodecExT.scala
@@ -21,6 +21,7 @@ class ConfCodecExT[S, A](encoder: ConfEncoder[A], decoder: ConfDecoderExT[S, A])
   def noTypos(implicit settings: Settings[A]): ConfCodecExT[S, A] =
     withDecoder(_.noTypos)
 
+  override def convert(conf: Conf): Conf = decoder.convert(conf)
 }
 
 object ConfCodecExT {

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfConverter.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfConverter.scala
@@ -1,0 +1,10 @@
+package metaconfig
+
+trait ConfConverter { self =>
+
+  def convert(conf: Conf): Conf
+
+  final def convert(conf: Configured[Conf]): Configured[Conf] = conf
+    .map(self.convert)
+
+}

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/NoTyposDecoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/NoTyposDecoder.scala
@@ -36,12 +36,14 @@ object NoTyposDecoder {
       extends ConfDecoder[A] {
     override def read(conf: Conf): Configured[A] =
       checkTypos(conf, dec.read(conf))
+    override def convert(conf: Conf): Conf = dec.convert(conf)
   }
 
   private class DecoderEx[-S, A: generic.Settings](dec: ConfDecoderExT[S, A])
       extends ConfDecoderExT[S, A] {
     override def read(state: Option[S], conf: Conf): Configured[A] =
       checkTypos(conf, dec.read(state, conf))
+    override def convert(conf: Conf): Conf = dec.convert(conf)
   }
 
 }

--- a/metaconfig-core/shared/src/main/scala/metaconfig/internal/SectionRenameDecoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/internal/SectionRenameDecoder.scala
@@ -11,6 +11,8 @@ trait SectionRenameDecoder[A] extends Transformable[A] { self: A =>
       conf: Conf,
       func: Conf => Configured[B],
   ): Configured[B] = func(renameSections(conf))
+  protected final def convertWith(conf: Conf, dec: ConfConverter): Conf = dec
+    .convert(renameSections(conf))
   private def renameSections(conf: Conf): Conf = SectionRenameDecoder
     .renameSections(renames)(conf)
 }
@@ -60,6 +62,7 @@ object SectionRenameDecoder {
       renameSectionsAnd(conf, dec.read)
     override def transform(f: SelfType => SelfType): SelfType =
       apply(f(dec), renames)
+    override def convert(conf: Conf): Conf = convertWith(conf, dec)
   }
 
   private class DecoderEx[S, A](
@@ -70,6 +73,7 @@ object SectionRenameDecoder {
       renameSectionsAnd(conf, dec.read(state, _))
     override def transform(f: SelfType => SelfType): SelfType =
       apply(f(dec), renames)
+    override def convert(conf: Conf): Conf = convertWith(conf, dec)
   }
 
   @tailrec


### PR DESCRIPTION
We have allow renaming config sections or deprecating old names, so let us add ability to determine what the currently canonical form of given config is.

Define trait ConfConverter, derive both ConfDecoderXxx traits from it, implement the conversion method wherever applicable.

Helps with scalameta/scalafmt#4884.