### PR TITLE
ConfDecoder: no partial-func contramap overload

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoder.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoder.scala
@@ -158,8 +158,6 @@ object ConfDecoder {
       override def read(conf: Conf): Configured[A] = self.read(f(conf))
       override def convert(conf: Conf): Conf = self.convert(f(conf))
     }
-    def contramap(f: PartialFunction[Conf, Conf]): ConfDecoder[A] =
-      contramap(x => f.applyOrElse(x, identity[Conf]))
 
     def detectSectionRenames(implicit
         settings: generic.Settings[A],

--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoderExT.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoderExT.scala
@@ -253,8 +253,6 @@ object ConfDecoderExT {
           .read(state, f(conf))
         override def convert(conf: Conf): Conf = self.convert(f(conf))
       }
-    def contramap(f: PartialFunction[Conf, Conf]): ConfDecoderExT[S, A] =
-      contramap(x => f.applyOrElse(x, identity[Conf]))
 
     def map[B](f: A => B): ConfDecoderExT[S, B] = new ConfDecoderExT[S, B] {
       override def read(state: Option[S], conf: Conf): Configured[B] = self


### PR DESCRIPTION
Scala 2.12 is unable to figure out which one of them to use, making both useless. Also, other similar methods (map, flatMap) do not do it.