### PR TITLE
SectionRenameDecoder: implement partial rename

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/annotation/Annotations.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/annotation/Annotations.scala
@@ -100,6 +100,12 @@ object SectionRename {
   )(oldName: String, newName: String): SectionRename =
     new SectionRename(oldName, newName, conv)
 
+  /** - if conv doesn't match, or returns null, value is not moved at all */
+  def partial(
+      conv: PartialFunction[Conf, Conf],
+  )(oldName: String, newName: String): SectionRename =
+    apply(oldName, newName, toFunc(conv, (_: Conf) => null))
+
   implicit def fromTuple(obj: (String, String)): SectionRename =
     apply(obj._1, obj._2)
 }

--- a/metaconfig-tests/jvm/src/test/scala/metaconfig/DeriveConfDecoderExJVMSuite.scala
+++ b/metaconfig-tests/jvm/src/test/scala/metaconfig/DeriveConfDecoderExJVMSuite.scala
@@ -234,7 +234,7 @@ class DeriveConfDecoderExJVMSuite extends munit.FunSuite {
     val nested = generic.deriveDecoderEx[Nested](Nested()).noTypos
       .withSectionRenames(
         SectionRename
-          .apply { case Conf.Str("xxx") => Conf.Str("yyy") }("E.A", "c.a"),
+          .partial { case Conf.Str("xxx") => Conf.Str("yyy") }("E.A", "c.a"),
         "E.A" -> "e.a",
       )
     checkOkStrEx(
@@ -255,9 +255,9 @@ class DeriveConfDecoderExJVMSuite extends munit.FunSuite {
            |  A = "zzz"
            |}
            |""".stripMargin,
-      out = Nested(c = Nested2(a = "zzz")),
+      out = Nested(e = Nested3(a = "zzz")),
       in = Nested(),
-      convConfStr = "c.a = zzz",
+      convConfStr = "e.a = zzz",
     )
   }
 


### PR DESCRIPTION
That is, if the conversion function is non empty and doesn't match, we do not modify the section.
