### PR TITLE
Conf: rename contramap with partial functions

### DIFF
--- a/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoderExT.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/ConfDecoderExT.scala
@@ -252,9 +252,11 @@ object ConfDecoderExT {
           .read(state, f(conf))
         override def convert(conf: Conf): Conf = self.convert(f(conf))
       }
-    def contramap(f: PartialFunction[Conf, Conf]): ConfDecoderExT[S, A] =
+    def contramapOpt(f: Conf => Option[Conf]): ConfDecoderExT[S, A] =
+      contramap(x => f(x).getOrElse(x))
+    def contramapPartial(f: PartialFunction[Conf, Conf]): ConfDecoderExT[S, A] =
       contramap(x => f.applyOrElse(x, identity[Conf]))
-    def contramapOpt(
+    def contramapPartialOpt(
         f: PartialFunction[Conf, Option[Conf]],
     ): ConfDecoderExT[S, A] =
       contramap(x => f.applyOrElse(x, (_: Conf) => None).getOrElse(x))


### PR DESCRIPTION
In scala 2.12, this overload produces an error:

The argument types of an anonymous function must be fully known. (SLS 8.5)