### PR TITLE
Drop redundant sbt-sonatype plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,4 +15,3 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % crossProje
 addSbtPlugin("org.scalameta"    % "sbt-mdoc"         % "2.9.0")
 addSbtPlugin("org.scala-js"     % "sbt-scalajs"      % "1.22.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
-addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"     % "3.12.2")


### PR DESCRIPTION
sbt-ci-release 1.12.0 no longer depends on xerial sbt-sonatype; it publishes via sbt-dynver, sbt-pgp and the Sonatype Central Portal built into the plugin. The build references no sonatype-plugin keys, so this line was already dead weight on sbt 1.x. It also has no sbt 2.x artifact, so removing it unblocks the sbt 2 upgrade.