### PR TITLE
sbt2 prep: scope the build-level settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val sharedJSSettings = Def.settings(
   scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
 )
 
-publish / skip := true
+LocalRootProject / publish / skip := true
 disablePlugins(MimaPlugin)
 
 lazy val depPaiges = libraryDependencies +=


### PR DESCRIPTION
A bare setting is build-wide in sbt 2.