### PR TITLE
sbt2 prep: name each project's settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,118 +155,145 @@ def depScalacheck = libraryDependencies ++= List(
   smorg %%% "munit-scalacheck" % V.munit % Test,
 )
 
+def pprintSettings = Def.settings(
+  sharedSettings,
+  mimaSettings,
+  moduleName := "metaconfig-pprint",
+  libraryDependencies += "com.lihaoyi" %%% "fansi" % "0.5.1",
+  libraryDependencies ++= {
+    if (scalaVersion.value.startsWith("2.")) List(
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+    )
+    else Nil
+  },
+)
+
 lazy val pprint = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-pprint")).settings(
-    sharedSettings,
-    mimaSettings,
-    moduleName := "metaconfig-pprint",
-    libraryDependencies += "com.lihaoyi" %%% "fansi" % "0.5.1",
-    libraryDependencies ++= {
-      if (scalaVersion.value.startsWith("2.")) List(
-        "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-        "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-      )
-      else Nil
-    },
-  ).jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-pprint"))
+  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-pprint"))
+  .settings(pprintSettings)
+  .jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-pprint"))
   .jsSettings(jsSources("metaconfig-pprint"))
   .nativeSettings(nativeSources("metaconfig-pprint"))
 
-lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-core")).settings(
-    sharedSettings,
-    mimaSettings,
-    moduleName := "metaconfig-core",
-    depPaiges,
-    libraryDependencies +=
-      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.14.0",
-  ).settings(libraryDependencies += {
+def coreSettings = Def.settings(
+  sharedSettings,
+  mimaSettings,
+  moduleName := "metaconfig-core",
+  depPaiges,
+  libraryDependencies +=
+    "org.scala-lang.modules" %%% "scala-collection-compat" % "2.14.0",
+  libraryDependencies += {
     val reflectVersion = if (isScala3.value) scala213 else scalaVersion.value
     "org.scala-lang" % "scala-reflect" % reflectVersion
-  }).dependsOn(pprint).nativeSettings(nativeSources("metaconfig-core"))
-  .jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-core")).jsSettings(
-    sharedJSSettings,
-    jsSources("metaconfig-core"),
-    libraryDependencies +=
-      smorg %%% "io" % "4.17.3" cross CrossVersion.for3Use2_13,
-  )
+  },
+)
+
+def coreJsSettings = Def.settings(
+  sharedJSSettings,
+  jsSources("metaconfig-core"),
+  libraryDependencies +=
+    (smorg %%% "io" % "4.17.3").cross(CrossVersion.for3Use2_13),
+)
+
+lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-core"))
+  .settings(coreSettings).dependsOn(pprint)
+  .nativeSettings(nativeSources("metaconfig-core"))
+  .jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-core"))
+  .jsSettings(coreJsSettings)
+
+def cliSettings = Def.settings(
+  sharedSettings,
+  mimaSettings,
+  moduleName := "metaconfig-cli",
+  depPaiges,
+)
 
 lazy val cli = crossProject(JVMPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-cli")).settings(
-    sharedSettings,
-    mimaSettings,
-    moduleName := "metaconfig-cli",
-    depPaiges,
-  ).jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-cli"))
+  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-cli")).settings(cliSettings)
+  .jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-cli"))
   .nativeSettings(nativeSources("metaconfig-cli")).dependsOn(core)
 
-lazy val typesafe = project.in(file("metaconfig-typesafe-config")).settings(
+def typesafeSettings = Def.settings(
   sharedSettings,
   mimaSettings,
   jvmReleaseSettings,
   moduleName := "metaconfig-typesafe-config",
   description := "Integration for HOCON using typesafehub/config.",
   libraryDependencies += "com.typesafe" % "config" % "1.4.9",
-).dependsOn(core.jvm)
+)
+
+lazy val typesafe = project.in(file("metaconfig-typesafe-config"))
+  .settings(typesafeSettings).dependsOn(core.jvm)
+
+def sconfigSettings = Def.settings(
+  sharedSettings,
+  mimaSettings,
+  moduleName := "metaconfig-sconfig",
+  description := "Integration for HOCON using ekrich/sconfig.",
+  libraryDependencies += ("org.ekrich" %%% "sconfig" % "2.0.0").excludeAll(
+    "org.scala-lang.modules" %
+      s"scala-collection-compat_${scalaBinaryVersion.value}",
+  ),
+)
+
+def sjavatime = Def
+  .settings(libraryDependencies += "org.ekrich" %%% "sjavatime" % "1.5.0")
 
 lazy val sconfig = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-sconfig")).settings(
-    sharedSettings,
-    mimaSettings,
-    moduleName := "metaconfig-sconfig",
-    description := "Integration for HOCON using ekrich/sconfig.",
-    libraryDependencies += ("org.ekrich" %%% "sconfig" % "2.0.0").excludeAll(
-      "org.scala-lang.modules" %
-        s"scala-collection-compat_${scalaBinaryVersion.value}",
-    ),
-  ).platformsSettings(JSPlatform, NativePlatform)(
-    libraryDependencies += "org.ekrich" %%% "sjavatime" % "1.5.0",
-  ).jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-sconfig"))
-  .jsSettings(sharedJSSettings, jsSources("metaconfig-sconfig"))
-  .nativeSettings(nativeSources("metaconfig-sconfig")).dependsOn(core)
+  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-sconfig"))
+  .settings(sconfigSettings)
+  .jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-sconfig"))
+  .jsSettings(sharedJSSettings, jsSources("metaconfig-sconfig"), sjavatime)
+  .nativeSettings(nativeSources("metaconfig-sconfig"), sjavatime).dependsOn(core)
+
+def testsSettings = Def.settings(
+  sharedSettings,
+  publish / skip := true,
+  Compile / packageDoc / publishArtifact := false,
+  testFrameworks := List(new TestFramework("munit.Framework")),
+  depScalacheck,
+)
+
+def testsJvmSettings = Def.settings(
+  jvmSources("metaconfig-tests"),
+  GraalVMNativeImage / mainClass := Some("metaconfig.tests.ExampleMain"),
+  Compile / doc / sources := Seq.empty,
+  libraryDependencies += {
+    if (isScala3.value) "org.typelevel" %% "shapeless3-deriving" % "3.6.0"
+    else "com.github.alexarchambault" %%% "scalacheck-shapeless_1.15" % "1.3.0"
+  },
+  graalVMNativeImageOptions ++= {
+    val reflectionFile = (Compile / Keys.sourceDirectory).value / "graal" /
+      "reflection.json"
+    assert(reflectionFile.exists, "no such file: " + reflectionFile)
+    List(
+      "-H:+ReportUnsupportedElementsAtRuntime",
+      "--initialize-at-build-time",
+      "--initialize-at-run-time=metaconfig",
+      "--no-server",
+      "--enable-http",
+      "--enable-https",
+      "-H:EnableURLProtocols=http,https",
+      "--enable-all-security-services",
+      "--no-fallback",
+      s"-H:ReflectionConfigurationFiles=$reflectionFile",
+      "--allow-incomplete-classpath",
+      "-H:+ReportExceptionStackTraces",
+    )
+  },
+)
 
 lazy val tests = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .withoutSuffixFor(JVMPlatform).in(file("metaconfig-tests"))
-  .disablePlugins(MimaPlugin).settings(
-    sharedSettings,
-    publish / skip := true,
-    Compile / packageDoc / publishArtifact := false,
-    testFrameworks := List(new TestFramework("munit.Framework")),
-    depScalacheck,
-  ).jsSettings(sharedJSSettings, jsSources("metaconfig-tests"))
-  .nativeSettings(nativeSources("metaconfig-tests")).jvmSettings(
-    jvmSources("metaconfig-tests"),
-    GraalVMNativeImage / mainClass := Some("metaconfig.tests.ExampleMain"),
-    Compile / doc / sources := Seq.empty,
-    libraryDependencies ++= {
-      if (scalaVersion.value.startsWith("2.")) Seq(
-        "com.github.alexarchambault" %%% "scalacheck-shapeless_1.15" % "1.3.0",
-      )
-      else Seq("org.typelevel" %% "shapeless3-deriving" % "3.6.0")
-    },
-    graalVMNativeImageOptions ++= {
-      val reflectionFile = (Compile / Keys.sourceDirectory).value / "graal" /
-        "reflection.json"
-      assert(reflectionFile.exists, "no such file: " + reflectionFile)
-      List(
-        "-H:+ReportUnsupportedElementsAtRuntime",
-        "--initialize-at-build-time",
-        "--initialize-at-run-time=metaconfig",
-        "--no-server",
-        "--enable-http",
-        "--enable-https",
-        "-H:EnableURLProtocols=http,https",
-        "--enable-all-security-services",
-        "--no-fallback",
-        s"-H:ReflectionConfigurationFiles=$reflectionFile",
-        "--allow-incomplete-classpath",
-        "-H:+ReportExceptionStackTraces",
-      )
-    },
-  ).jvmEnablePlugins(GraalVMNativeImagePlugin)
+  .disablePlugins(MimaPlugin).settings(testsSettings)
+  .jsSettings(sharedJSSettings, jsSources("metaconfig-tests"))
+  .nativeSettings(nativeSources("metaconfig-tests"))
+  .jvmSettings(testsJvmSettings).jvmEnablePlugins(GraalVMNativeImagePlugin)
   .jvmConfigure(_.dependsOn(typesafe, cli.jvm)).dependsOn(core, sconfig)
 
-lazy val docs = project.in(file("metaconfig-docs")).settings(
+def docsSettings = Def.settings(
   sharedSettings,
   depScalacheck,
   libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.13.1",
@@ -282,5 +309,8 @@ lazy val docs = project.in(file("metaconfig-docs")).settings(
   mdocExtraArguments := List("--no-link-hygiene"),
   // mdoc's metaconfig might (and will eventually) lag behind the current version, causing eviction errors
   evictionErrorLevel := Level.Warn,
-).dependsOn(core.jvm, typesafe, sconfig.jvm).enablePlugins(DocusaurusPlugin)
+)
+
+lazy val docs = project.in(file("metaconfig-docs")).settings(docsSettings)
+  .dependsOn(core.jvm, typesafe, sconfig.jvm).enablePlugins(DocusaurusPlugin)
   .disablePlugins(MimaPlugin)


### PR DESCRIPTION
A project reads as a chain of calls once its settings have a name, and the matrix conversion then changes the chain alone.