### PR TITLE
sbt2 prep: give the build an Extensions object

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,9 @@
 import com.typesafe.tools.mima.core._
 
+import Extensions._
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-val scala212 = "2.12.21"
-
-val scala213 = "2.13.18"
-
-val scala3 = "3.3.8"
-
-def isScala213 = Def.setting(scalaBinaryVersion.value == "2.13")
-def isScala3 = Def.setting(scalaVersion.value.startsWith("3."))
-
 val smorg = "org.scalameta"
-val ScalaVersions = List(scala213, scala212, scala3)
 inThisBuild(List(
   // version is set dynamically by sbt-dynver, but let's adjust it
   version := {
@@ -75,30 +66,6 @@ val languageAgnosticCompatibilityPolicy: ProblemFilter = (problem: Problem) => {
     fullName.startsWith("metaconfig.cli")
   public && include && !exclude
 }
-
-def srcWithRoot(root: File, dir: String) = root / dir / "src"
-
-// crossProject's layout, wired by hand: a matrix has one base directory, so
-// each cell names the trees it shares. Absent directories are harmless.
-def roots(name: String, cfg: String, dirs: String*) = Def.setting[Seq[File]] {
-  val variants =
-    List("scala", "java", if (isScala3.value) "scala-3" else "scala-2")
-  val root = (ThisBuild / baseDirectory).value / name
-  for (dir <- dirs; base = srcWithRoot(root, dir) / cfg; variant <- variants)
-    yield base / variant
-}
-
-def unmanagedSources(name: String, dirs: String*) = Def.settings(
-  Compile / unmanagedSourceDirectories ++= roots(name, "main", dirs: _*).value,
-  Test / unmanagedSourceDirectories ++= roots(name, "test", dirs: _*).value,
-)
-
-def jvmSources(name: String) =
-  unmanagedSources(name, "shared", "jvm", "js-jvm", "jvm-native")
-def jsSources(name: String) =
-  unmanagedSources(name, "shared", "js", "js-jvm", "js-native")
-def nativeSources(name: String) =
-  unmanagedSources(name, "shared", "native", "jvm-native", "js-native")
 
 lazy val sharedSettings = Def.settings(
   scalacOptions ++= { if (isScala3.value) Nil else Seq("-Yrangepos") },

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -1,0 +1,41 @@
+import sbt.Keys._
+import sbt._
+
+object Extensions {
+
+  val scala212 = "2.12.21"
+
+  val scala213 = "2.13.18"
+
+  val scala3 = "3.3.8"
+
+  val ScalaVersions = List(scala213, scala212, scala3)
+
+  def isScala213 = Def.setting(scalaBinaryVersion.value == "2.13")
+  def isScala3 = Def.setting(scalaVersion.value.startsWith("3."))
+
+  def srcWithRoot(root: File, dir: String) = root / dir / "src"
+
+  // crossProject's layout, wired by hand: a matrix has one base directory, so
+  // each cell names the trees it shares. Absent directories are harmless.
+  private def roots(name: String, cfg: String, dirs: String*) = Def.setting {
+    val variants =
+      List("scala", "java", if (isScala3.value) "scala-3" else "scala-2")
+    val root = (ThisBuild / baseDirectory).value / name
+    for (dir <- dirs; base = srcWithRoot(root, dir) / cfg; variant <- variants)
+      yield base / variant
+  }
+
+  private def unmanagedSources(name: String, dirs: String*) = Def.settings(
+    Compile / unmanagedSourceDirectories ++= roots(name, "main", dirs: _*).value,
+    Test / unmanagedSourceDirectories ++= roots(name, "test", dirs: _*).value,
+  )
+
+  def jvmSources(name: String) =
+    unmanagedSources(name, "shared", "jvm", "js-jvm", "jvm-native")
+  def jsSources(name: String) =
+    unmanagedSources(name, "shared", "js", "js-jvm", "js-native")
+  def nativeSources(name: String) =
+    unmanagedSources(name, "shared", "native", "jvm-native", "js-native")
+
+}


### PR DESCRIPTION
The Scala versions and the two version tests are the build's own values, not settings, and the matrix work to come adds more of them.