### PR TITLE
sbt2 prep: use projectMatrix, not crossProject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import com.typesafe.tools.mima.core._
 
 import Extensions._
-import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 val smorg = "org.scalameta"
 inThisBuild(List(
@@ -35,14 +34,19 @@ inThisBuild(List(
   versionScheme := Some("early-semver"),
 ))
 
-addCommandAlias(
-  "scalafixAll",
-  s"; ++$scala212 ; scalafixEnable ; all scalafix test:scalafix",
-)
-addCommandAlias(
-  "scalafixCheckAll",
-  s"; ++$scala212 ;  scalafixEnable ; scalafix --check ; test:scalafix --check",
-)
+def onEach(ps: Seq[Project], tasks: String*) = tasks
+  .flatMap(t => ps.map(p => s"${p.id}/$t")).mkString("; ", "; ", "")
+
+// ++ sets one Scala version for the whole build, and a row of another version
+// then resolves its siblings at that suffix, so scalafix names its rows
+def scalafixOn(args: String) = {
+  val targets = Seq(pprint, core, cli, sconfig, typesafe, tests, docs)
+    .map(_.jvm(scala212))
+  "; scalafixEnable" + onEach(targets, s"scalafix $args", s"Test/scalafix $args")
+}
+
+addCommandAlias("scalafixAll", scalafixOn(""))
+addCommandAlias("scalafixCheckAll", scalafixOn("--check"))
 
 addCommandAlias(
   "native-image",
@@ -83,8 +87,6 @@ lazy val sharedSettings = Def.settings(
   scalacOptions ++=
     { if (isScala3.value) Nil else "-Wconf:cat=feature:is" :: Nil },
   mimaBinaryIssueFilters += languageAgnosticCompatibilityPolicy,
-  crossScalaVersions := ScalaVersions,
-  scalaVersion := scala213,
 )
 
 lazy val mimaSettings = Def.settings(
@@ -103,7 +105,6 @@ lazy val jvmReleaseSettings = Def.settings(
 )
 
 lazy val sharedJSSettings = Def.settings(
-  crossScalaVersions := ScalaVersions,
   // to support Node.JS functionality
   scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
 )
@@ -132,12 +133,8 @@ def pprintSettings = Def.settings(
   },
 )
 
-lazy val pprint = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-pprint"))
-  .settings(pprintSettings)
-  .jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-pprint"))
-  .jsSettings(jsSources("metaconfig-pprint"))
-  .nativeSettings(nativeSources("metaconfig-pprint"))
+lazy val pprint = projectMatrix.in(file("metaconfig-pprint"))
+  .settings(pprintSettings).crossJvm(jvmReleaseSettings).crossJs().crossNative()
 
 def coreSettings = Def.settings(
   sharedSettings,
@@ -154,17 +151,13 @@ def coreSettings = Def.settings(
 
 def coreJsSettings = Def.settings(
   sharedJSSettings,
-  jsSources("metaconfig-core"),
   libraryDependencies +=
     (smorg %%% "io" % "4.17.3").cross(CrossVersion.for3Use2_13),
 )
 
-lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-core"))
-  .settings(coreSettings).dependsOn(pprint)
-  .nativeSettings(nativeSources("metaconfig-core"))
-  .jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-core"))
-  .jsSettings(coreJsSettings)
+lazy val core = projectMatrix.in(file("metaconfig-core")).settings(coreSettings)
+  .dependsOn(pprint).crossNative().crossJvm(jvmReleaseSettings)
+  .crossJs(coreJsSettings)
 
 def cliSettings = Def.settings(
   sharedSettings,
@@ -173,10 +166,8 @@ def cliSettings = Def.settings(
   depPaiges,
 )
 
-lazy val cli = crossProject(JVMPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-cli")).settings(cliSettings)
-  .jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-cli"))
-  .nativeSettings(nativeSources("metaconfig-cli")).dependsOn(core)
+lazy val cli = projectMatrix.in(file("metaconfig-cli")).settings(cliSettings)
+  .crossJvm(jvmReleaseSettings).crossNative().dependsOn(core)
 
 def typesafeSettings = Def.settings(
   sharedSettings,
@@ -187,8 +178,8 @@ def typesafeSettings = Def.settings(
   libraryDependencies += "com.typesafe" % "config" % "1.4.9",
 )
 
-lazy val typesafe = project.in(file("metaconfig-typesafe-config"))
-  .settings(typesafeSettings).dependsOn(core.jvm)
+lazy val typesafe = projectMatrix.in(file("metaconfig-typesafe-config"))
+  .settings(typesafeSettings).jvmPlatform(ScalaVersions).dependsOn(core)
 
 def sconfigSettings = Def.settings(
   sharedSettings,
@@ -204,12 +195,9 @@ def sconfigSettings = Def.settings(
 def sjavatime = Def
   .settings(libraryDependencies += "org.ekrich" %%% "sjavatime" % "1.5.0")
 
-lazy val sconfig = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-sconfig"))
-  .settings(sconfigSettings)
-  .jvmSettings(jvmReleaseSettings, jvmSources("metaconfig-sconfig"))
-  .jsSettings(sharedJSSettings, jsSources("metaconfig-sconfig"), sjavatime)
-  .nativeSettings(nativeSources("metaconfig-sconfig"), sjavatime).dependsOn(core)
+lazy val sconfig = projectMatrix.in(file("metaconfig-sconfig"))
+  .settings(sconfigSettings).crossJvm(jvmReleaseSettings)
+  .crossJs(sharedJSSettings, sjavatime).crossNative(sjavatime).dependsOn(core)
 
 def testsSettings = Def.settings(
   sharedSettings,
@@ -219,8 +207,9 @@ def testsSettings = Def.settings(
   depScalacheck,
 )
 
+// typesafe has only JVM rows and cli has no JS row, so the JVM rows name the
+// version they depend on rather than the matrix
 def testsJvmSettings = Def.settings(
-  jvmSources("metaconfig-tests"),
   GraalVMNativeImage / mainClass := Some("metaconfig.tests.ExampleMain"),
   Compile / doc / sources := Seq.empty,
   libraryDependencies += {
@@ -228,7 +217,7 @@ def testsJvmSettings = Def.settings(
     else "com.github.alexarchambault" %%% "scalacheck-shapeless_1.15" % "1.3.0"
   },
   graalVMNativeImageOptions ++= {
-    val reflectionFile = (Compile / Keys.sourceDirectory).value / "graal" /
+    val reflectionFile = srcDir("jvm").value / "main" / "graal" /
       "reflection.json"
     assert(reflectionFile.exists, "no such file: " + reflectionFile)
     List(
@@ -248,13 +237,12 @@ def testsJvmSettings = Def.settings(
   },
 )
 
-lazy val tests = crossProject(JVMPlatform, JSPlatform, NativePlatform)
-  .withoutSuffixFor(JVMPlatform).in(file("metaconfig-tests"))
-  .disablePlugins(MimaPlugin).settings(testsSettings)
-  .jsSettings(sharedJSSettings, jsSources("metaconfig-tests"))
-  .nativeSettings(nativeSources("metaconfig-tests"))
-  .jvmSettings(testsJvmSettings).jvmEnablePlugins(GraalVMNativeImagePlugin)
-  .jvmConfigure(_.dependsOn(typesafe, cli.jvm)).dependsOn(core, sconfig)
+lazy val tests = projectMatrix.in(file("metaconfig-tests"))
+  .settings(testsSettings).crossJs(sharedJSSettings).crossNative()
+  .crossJvmRows(v =>
+    _.enablePlugins(GraalVMNativeImagePlugin).settings(testsJvmSettings)
+      .dependsOn(typesafe.jvm(v), cli.jvm(v)),
+  ).disablePlugins(MimaPlugin).dependsOn(core, sconfig)
 
 def docsSettings = Def.settings(
   sharedSettings,
@@ -274,6 +262,6 @@ def docsSettings = Def.settings(
   evictionErrorLevel := Level.Warn,
 )
 
-lazy val docs = project.in(file("metaconfig-docs")).settings(docsSettings)
-  .dependsOn(core.jvm, typesafe, sconfig.jvm).enablePlugins(DocusaurusPlugin)
-  .disablePlugins(MimaPlugin)
+lazy val docs = projectMatrix.in(file("metaconfig-docs")).settings(docsSettings)
+  .jvmPlatform(ScalaVersions).dependsOn(core, typesafe, sconfig)
+  .enablePlugins(DocusaurusPlugin).disablePlugins(MimaPlugin)

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -1,5 +1,8 @@
 import sbt.Keys._
 import sbt._
+import sbt.internal.ProjectMatrix
+
+import sbtprojectmatrix.ProjectMatrixPlugin.autoImport.projectMatrixBaseDirectory
 
 object Extensions {
 
@@ -14,28 +17,56 @@ object Extensions {
   def isScala213 = Def.setting(scalaBinaryVersion.value == "2.13")
   def isScala3 = Def.setting(scalaVersion.value.startsWith("3."))
 
-  def srcWithRoot(root: File, dir: String) = root / dir / "src"
+  // sbt gives every matrix cell a generated baseDirectory, so a source tree
+  // starts from the matrix base instead
+  def srcDir(tree: String) = Def.setting(matrixBase.value / tree / "src")
+
+  // `in` records the file it is given, so the base can be relative
+  private def matrixBase = Def.setting(IO.resolve(
+    (ThisBuild / baseDirectory).value,
+    projectMatrixBaseDirectory.value,
+  ))
 
   // crossProject's layout, wired by hand: a matrix has one base directory, so
   // each cell names the trees it shares. Absent directories are harmless.
-  private def roots(name: String, cfg: String, dirs: String*) = Def.setting {
+  private def roots(cfg: String, trees: Seq[String]) = Def.setting {
     val variants =
       List("scala", "java", if (isScala3.value) "scala-3" else "scala-2")
-    val root = (ThisBuild / baseDirectory).value / name
-    for (dir <- dirs; base = srcWithRoot(root, dir) / cfg; variant <- variants)
-      yield base / variant
+    val base = matrixBase.value
+    for (tree <- trees; src = base / tree / "src" / cfg; variant <- variants)
+      yield src / variant
   }
 
-  private def unmanagedSources(name: String, dirs: String*) = Def.settings(
-    Compile / unmanagedSourceDirectories ++= roots(name, "main", dirs: _*).value,
-    Test / unmanagedSourceDirectories ++= roots(name, "test", dirs: _*).value,
+  private def unmanagedSources(trees: String*) = Def.settings(
+    Compile / unmanagedSourceDirectories ++= roots("main", trees).value,
+    Test / unmanagedSourceDirectories ++= roots("test", trees).value,
   )
 
-  def jvmSources(name: String) =
-    unmanagedSources(name, "shared", "jvm", "js-jvm", "jvm-native")
-  def jsSources(name: String) =
-    unmanagedSources(name, "shared", "js", "js-jvm", "js-native")
-  def nativeSources(name: String) =
-    unmanagedSources(name, "shared", "native", "jvm-native", "js-native")
+  private def jvmSources =
+    unmanagedSources("shared", "jvm", "js-jvm", "jvm-native")
+  private def jsSources = unmanagedSources("shared", "js", "js-jvm", "js-native")
+  private def nativeSources =
+    unmanagedSources("shared", "native", "jvm-native", "js-native")
+
+  implicit class ProjectMatrixExtensions(private val self: ProjectMatrix)
+      extends AnyVal {
+
+    def crossJvm(ss: Def.SettingsDefinition*): ProjectMatrix = self
+      .jvmPlatform(ScalaVersions, jvmSources ++ ss.flatMap(_.settings))
+
+    def crossJs(ss: Def.SettingsDefinition*): ProjectMatrix = self
+      .jsPlatform(ScalaVersions, jsSources ++ ss.flatMap(_.settings))
+
+    def crossNative(ss: Def.SettingsDefinition*): ProjectMatrix = self
+      .nativePlatform(ScalaVersions, nativeSources ++ ss.flatMap(_.settings))
+
+    // one row per Scala version, for rows that name their own dependencies
+    def crossJvmRows(configure: String => Project => Project): ProjectMatrix =
+      ScalaVersions.foldLeft(self) { (matrix, version) =>
+        val func = configure(version).andThen(_.settings(jvmSources))
+        matrix.jvmPlatform(Seq(version), Nil, func)
+      }
+
+  }
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,4 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % crossProje
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.9.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")


### PR DESCRIPTION
Each row is a project of its own, so the version lists move into jvmPlatform/jsPlatform/nativePlatform and crossScalaVersions goes away, as does the scalaVersion default that would have overridden every row. typesafe and docs become JVM-only matrices so the rows they serve can depend on their own version, and tests names its JVM-only dependencies per version. CI drops the + from test: the aggregate already covers every row, and ++ no longer selects them.