### PR TITLE
Split CI into a gate and a post-merge superset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,83 @@ on:
     branches:
       - main
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# One definition, two views. The `pr-*` jobs carry the whole gate and have no
+# event guard, so they run on pull_request AND push. Push then ADDS `post-*`:
+# the other JDK, Windows, and the Scala versions the gate only compiles.
+# Nothing is restated, so the two views cannot drift apart.
+#
+# Within a worker each command is its own `!cancelled()` step, so a failure
+# never masks its siblings — one run shows all of them.
+
 jobs:
-  build:
+  pr-jvm213-lint: # 2.13 on the JVM, then formatting, scalafix, MiMa, docs
+    name: JVM-213, linting, MiMa, docs
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # the mima baseline is the last tag
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - if: ${{ !cancelled() }}
+        run: sbt '++2.13 tests/test'
+      - if: ${{ !cancelled() }}
+        run: sbt '++2.13 docs/test'
+      - if: ${{ !cancelled() }}
+        run: ./bin/scalafmt --check
+      - if: ${{ !cancelled() }}
+        run: sbt scalafixCheckAll
+      - if: ${{ !cancelled() }}
+        run: sbt mimaReportBinaryIssues
+      - if: ${{ !cancelled() }}
+        run: sbt docs/docusaurusCreateSite
+
+  pr-all3-nonjvm213: # 2.13 on JS and Native, 3.x everywhere, 2.12 compiled
+    name: All-3, nonJVM-213, 2.12 compile
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - if: ${{ !cancelled() }}
+        run: sbt '++2.13 testsJS/test'
+      - if: ${{ !cancelled() }}
+        run: sbt '++2.13 testsNative/test'
+      - if: ${{ !cancelled() }}
+        run: sbt '++2.12 Test/compile'
+      - if: ${{ !cancelled() }}
+        run: sbt '++3.x test'
+
+  post-cross: # every Scala version, on both JDKs and both operating systems
     name: ${{ matrix.os }} jdk-${{ matrix.java }} tests
+    if: ${{ github.event_name == 'push' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022]
-        # Build on modern JDKs; -release (see build.sbt) keeps the published
-        # artifacts JDK 8-compatible, so a JDK 8/11 runner isn't needed.
-        java: [17, 21]
+        # Runs on modern JDKs but produces JDK8-compatible bytecode.
+        # Split in such a way as to keep the workers even.
+        # NB: the versions must be padded by a space!
+        include:
+          - os: ubuntu-22.04
+            java: 21 # 17 is tested above
+            versions: ' 2.13 2.12 3.x '
+          - os: windows-2022
+            java: 17
+            versions: ' 2.13 2.12 '
+          - os: windows-2022
+            java: 21
+            versions: ' 2.13 3.x '
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5
@@ -30,25 +96,16 @@ jobs:
       # it does not matter whether it would be used or not, the amount of all
       # reserved memory cannot exceed the amount of physically available storage.
       - name: Configure Pagefile
-        if: matrix.os == 'windows-2019'
+        if: startsWith(matrix.os, 'windows')
         uses: al-cheb/configure-pagefile-action@v1.5
         with:
           minimum-size: 4GB
           maximum-size: 16GB
-      - name: Test
-        run: sbt +test
-  checks:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          # the mima baseline is the last tag
-          fetch-depth: 0
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-      - run: ./bin/scalafmt --check
-      - run: sbt scalafixCheckAll
-      - run: sbt mimaReportBinaryIssues
-      - run: sbt docs/docusaurusCreateSite
+      # one step per version: each is its own group in the log, and Windows
+      # cannot commit the heaps for two versions' native binaries at once
+      - if: ${{ !cancelled() && contains(matrix.versions, ' 2.13 ') }}
+        run: sbt '++2.13 test'
+      - if: ${{ !cancelled() && contains(matrix.versions, ' 2.12 ') }}
+        run: sbt '++2.12 test'
+      - if: ${{ !cancelled() && contains(matrix.versions, ' 3.x ') }}
+        run: sbt '++3.x test'


### PR DESCRIPTION
Six scala-steward merges landed within 70 seconds on 8 June; the thirty jobs they queued left the last one waiting 83 minutes. A pull request now costs two workers, a push five as before.

Every version is still tested on each JDK and each OS, no longer on every pair of them.

The pagefile step had asked for windows-2019 since the matrix moved to windows-2022, so Windows ran without it.