### PR TITLE
sbt2: switch from 1.12.15 to 2.0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - if: ${{ !cancelled() }}
-        run: sbt '++2.13 tests/test'
+        run: sbt '++2.13; tests/testFull'
       - if: ${{ !cancelled() }}
-        run: sbt '++2.13 docs/test'
+        run: sbt '++2.13; docs/testFull'
       - if: ${{ !cancelled() }}
         run: ./bin/scalafmt --check
       - if: ${{ !cancelled() }}
@@ -53,13 +53,13 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - if: ${{ !cancelled() }}
-        run: sbt '++2.13 testsJS/test'
+        run: sbt '++2.13; testsJS/testFull'
       - if: ${{ !cancelled() }}
-        run: sbt '++2.13 testsNative/test'
+        run: sbt '++2.13; testsNative/testFull'
       - if: ${{ !cancelled() }}
-        run: sbt '++2.12 Test/compile'
+        run: sbt '++2.12; Test/compile'
       - if: ${{ !cancelled() }}
-        run: sbt '++3.x test'
+        run: sbt '++3.x; testFull'
 
   post-cross: # every Scala version, on both JDKs and both operating systems
     name: ${{ matrix.os }} jdk-${{ matrix.java }} tests
@@ -104,8 +104,8 @@ jobs:
       # one step per version: each is its own group in the log, and Windows
       # cannot commit the heaps for two versions' native binaries at once
       - if: ${{ !cancelled() && contains(matrix.versions, ' 2.13 ') }}
-        run: sbt '++2.13 test'
+        run: sbt '++2.13; testFull'
       - if: ${{ !cancelled() && contains(matrix.versions, ' 2.12 ') }}
-        run: sbt '++2.12 test'
+        run: sbt '++2.12; testFull'
       - if: ${{ !cancelled() && contains(matrix.versions, ' 3.x ') }}
-        run: sbt '++3.x test'
+        run: sbt '++3.x; testFull'

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,9 @@ inThisBuild(List(
     url("https://geirsson.com"),
   ),
   resolvers += Resolver.sonatypeCentralSnapshots,
+  // munit and scalacheck pull older test-interface builds than the Native
+  // plugin does, and sbt 2 treats that as an error rather than a warning
+  evictionErrorLevel := Level.Warn,
   versionScheme := Some("early-semver"),
 ))
 
@@ -113,17 +116,17 @@ LocalRootProject / publish / skip := true
 disablePlugins(MimaPlugin)
 
 lazy val depPaiges = libraryDependencies +=
-  "org.typelevel" %%% "paiges-core" % "0.4.4"
+  "org.typelevel" %% "paiges-core" % "0.4.4"
 def depScalacheck = libraryDependencies ++= List(
-  "org.scalacheck" %%% "scalacheck" % "1.19.0",
-  smorg %%% "munit-scalacheck" % "1.3.0" % Test,
+  "org.scalacheck" %% "scalacheck" % "1.19.0",
+  smorg %% "munit-scalacheck" % "1.3.0" % Test,
 )
 
 def pprintSettings = Def.settings(
   sharedSettings,
   mimaSettings,
   moduleName := "metaconfig-pprint",
-  libraryDependencies += "com.lihaoyi" %%% "fansi" % "0.5.1",
+  libraryDependencies += "com.lihaoyi" %% "fansi" % "0.5.1",
   libraryDependencies ++= {
     if (scalaVersion.value.startsWith("2.")) List(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
@@ -142,7 +145,7 @@ def coreSettings = Def.settings(
   moduleName := "metaconfig-core",
   depPaiges,
   libraryDependencies +=
-    "org.scala-lang.modules" %%% "scala-collection-compat" % "2.14.0",
+    "org.scala-lang.modules" %% "scala-collection-compat" % "2.14.0",
   libraryDependencies += {
     val reflectVersion = if (isScala3.value) scala213 else scalaVersion.value
     "org.scala-lang" % "scala-reflect" % reflectVersion
@@ -152,7 +155,7 @@ def coreSettings = Def.settings(
 def coreJsSettings = Def.settings(
   sharedJSSettings,
   libraryDependencies +=
-    (smorg %%% "io" % "4.17.3").cross(CrossVersion.for3Use2_13),
+    (smorg %% "io" % "4.17.3").cross(CrossVersion.for3Use2_13),
 )
 
 lazy val core = projectMatrix.in(file("metaconfig-core")).settings(coreSettings)
@@ -186,14 +189,14 @@ def sconfigSettings = Def.settings(
   mimaSettings,
   moduleName := "metaconfig-sconfig",
   description := "Integration for HOCON using ekrich/sconfig.",
-  libraryDependencies += ("org.ekrich" %%% "sconfig" % "2.0.0").excludeAll(
+  libraryDependencies += ("org.ekrich" %% "sconfig" % "2.0.0").excludeAll(
     "org.scala-lang.modules" %
       s"scala-collection-compat_${scalaBinaryVersion.value}",
   ),
 )
 
 def sjavatime = Def
-  .settings(libraryDependencies += "org.ekrich" %%% "sjavatime" % "1.5.0")
+  .settings(libraryDependencies += "org.ekrich" %% "sjavatime" % "1.5.0")
 
 lazy val sconfig = projectMatrix.in(file("metaconfig-sconfig"))
   .settings(sconfigSettings).crossJvm(jvmReleaseSettings)
@@ -214,7 +217,7 @@ def testsJvmSettings = Def.settings(
   Compile / doc / sources := Seq.empty,
   libraryDependencies += {
     if (isScala3.value) "org.typelevel" %% "shapeless3-deriving" % "3.6.0"
-    else "com.github.alexarchambault" %%% "scalacheck-shapeless_1.15" % "1.3.0"
+    else "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0"
   },
   graalVMNativeImageOptions ++= {
     val reflectionFile = srcDir("jvm").value / "main" / "graal" /
@@ -247,7 +250,7 @@ lazy val tests = projectMatrix.in(file("metaconfig-tests"))
 def docsSettings = Def.settings(
   sharedSettings,
   depScalacheck,
-  libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.13.1",
+  libraryDependencies += "com.lihaoyi" %% "scalatags" % "0.13.1",
   publish / skip := true,
   dependencyOverrides +=
     smorg %% "metaconfig-typesafe-config" % (ThisBuild / version).value,

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -1,8 +1,5 @@
 import sbt.Keys._
 import sbt._
-import sbt.internal.ProjectMatrix
-
-import sbtprojectmatrix.ProjectMatrixPlugin.autoImport.projectMatrixBaseDirectory
 
 object Extensions {
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.15
+sbt.version=2.0.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 // scalafmt: { maxColumn = 100 }
 
-val crossProjectV = "1.4.0"
-
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")
@@ -9,10 +7,6 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.1")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % crossProjectV)
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % crossProjectV)
-
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.9.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")


### PR DESCRIPTION
sbt 2 in-sources the matrix, so sbt-projectmatrix and the crossproject plugins go, and %%% becomes %%, which carries the platform now. munit and scalacheck pull older test-interface builds than the Native plugin does, and sbt 2 calls that an error rather than a warning. Closes #505. Closes #492.