### PR TITLE
Ask for a pagefile that fits the disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,20 +87,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      # We need to set proper Pagefile limits in advance.
-      # Github actions default page file size is quite small,
-      # it's not enough to run all tests, especially when using None GC.
-      # We've observed that on Unix memory management is less strict,
-      # you can reserve more memory than it's physically possible.
-      # On Windows however you need to reserve/commit memory in advance -
-      # it does not matter whether it would be used or not, the amount of all
-      # reserved memory cannot exceed the amount of physically available storage.
+      # Windows commits reserved memory up front, unlike Unix, and the runner's
+      # own pagefile is too small for the native tests. The maximum has to fit
+      # the temp disk, which holds 14GB in total.
       - name: Configure Pagefile
         if: startsWith(matrix.os, 'windows')
         uses: al-cheb/configure-pagefile-action@v1.5
         with:
           minimum-size: 4GB
-          maximum-size: 16GB
+          maximum-size: 8GB
       # one step per version: each is its own group in the log, and Windows
       # cannot commit the heaps for two versions' native binaries at once
       - if: ${{ !cancelled() && contains(matrix.versions, ' 2.13 ') }}


### PR DESCRIPTION
The action raised "The operation completed successfully" and left the pagefile alone. Its own issue #18 reports the same for a minimum of 13GB where 12GB works, so the 16GB maximum was the problem: the runner's temp disk holds 14GB in total.