### PR TITLE
Release on the JDK that sbt 2 requires

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: olafurpg/setup-gpg@v3
       - name: Publish ${{ github.ref }}
         run: sbt ci-release


### PR DESCRIPTION
sbt 2 refuses to start on JDK 11. The artifacts still target JDK 8: -release pins that, whatever JDK runs the build.