### PR TITLE
Cap the heap of the native test binaries

### DIFF
--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -45,6 +45,12 @@ object Extensions {
   private def nativeSources =
     unmanagedSources("shared", "native", "jvm-native", "js-native")
 
+  // a test binary commits a bytemap of a sixteenth of its maximum heap before
+  // it runs, and Windows cannot overcommit; the maximum defaults to the memory
+  // of the machine, so a few binaries at once fill the commit limit
+  private def nativeHeap = Def
+    .settings(Test / envVars += "GC_MAXIMUM_HEAP_SIZE" -> "512m")
+
   implicit class ProjectMatrixExtensions(private val self: ProjectMatrix)
       extends AnyVal {
 
@@ -55,7 +61,10 @@ object Extensions {
       .jsPlatform(ScalaVersions, jsSources ++ ss.flatMap(_.settings))
 
     def crossNative(ss: Def.SettingsDefinition*): ProjectMatrix = self
-      .nativePlatform(ScalaVersions, nativeSources ++ ss.flatMap(_.settings))
+      .nativePlatform(
+        ScalaVersions,
+        nativeSources ++ nativeHeap ++ ss.flatMap(_.settings),
+      )
 
     // one row per Scala version, for rows that name their own dependencies
     def crossJvmRows(configure: String => Project => Project): ProjectMatrix =


### PR DESCRIPTION
The immix GC commits the metadata for the whole maximum heap before a test binary runs, and the maximum defaults to the memory of the machine. On a 16GB runner that is 1.1GB per process, nearly all of it the bytemap. Windows cannot overcommit, so a handful of binaries at once fill the commit limit and the GC exits with "Out of heap space commit memmory". A 512MB maximum asks for 38MB per process; the tests use a few MB.