### PR TITLE
Extensions: let the IDE import one Scala version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,22 @@ Please refer to the
 contributing guidelines to learn more about how to report tickets and open pull
 requests.
 
+## IntelliJ
+
+IntelliJ imports the project for one Scala version, 2.13 by default,
+because it puts the sources that the matrix cells share into a single
+module: importing every cell compiles the Scala 2 and the Scala 3 copies
+of `metaconfig.generic` and `metaconfig.pprint` together. If you need to
+modify the defaults, set the properties below under
+`Settings -> Build, Execution, Deployment -> Build Tools -> sbt -> VM parameters`
+and reload the sbt project:
+
+- `-Dide.scala=X`: imports Scala version `X` instead (could be `2.12`, `2.13`,
+  or `3`). `-Dide.scala=`, with no value, imports the default.
+- `-Dide.platform=Y`: if `Y` is empty, imports all platforms; otherwise, `Y` is
+  a comma-separated list of platforms to import, and `jvm` is implied, whether
+  or not it is explicitly listed, while `js` and `native` are optional.
+
 ## Website
 
 The website is built with [GitBook](https://www.npmjs.com/package/gitbook-cli).

--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ def typesafeSettings = Def.settings(
 )
 
 lazy val typesafe = projectMatrix.in(file("metaconfig-typesafe-config"))
-  .settings(typesafeSettings).jvmPlatform(ScalaVersions).dependsOn(core)
+  .settings(typesafeSettings).crossJvmPlain.dependsOn(core)
 
 def sconfigSettings = Def.settings(
   sharedSettings,
@@ -266,5 +266,5 @@ def docsSettings = Def.settings(
 )
 
 lazy val docs = projectMatrix.in(file("metaconfig-docs")).settings(docsSettings)
-  .jvmPlatform(ScalaVersions).dependsOn(core, typesafe, sconfig)
+  .crossJvmPlain.dependsOn(core, typesafe, sconfig)
   .enablePlugins(DocusaurusPlugin).disablePlugins(MimaPlugin)

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -39,11 +39,19 @@ object Extensions {
     Test / unmanagedSourceDirectories ++= roots("test", trees).value,
   )
 
-  private def jvmSources =
-    unmanagedSources("shared", "jvm", "js-jvm", "jvm-native")
-  private def jsSources = unmanagedSources("shared", "js", "js-jvm", "js-native")
-  private def nativeSources =
-    unmanagedSources("shared", "native", "jvm-native", "js-native")
+  private def platformSources(
+      platform: String,
+      ss: Seq[Def.SettingsDefinition],
+      platforms: String*,
+  ) = unmanagedSources("shared" +: platform +: platforms *) ++
+    ideSkip(platform) ++ ss.flatMap(_.settings)
+
+  private def jvmSources(ss: Seq[Def.SettingsDefinition]) =
+    platformSources("jvm", ss, "js-jvm", "jvm-native")
+  private def jsSources(ss: Seq[Def.SettingsDefinition]) =
+    platformSources("js", ss, "js-jvm", "js-native")
+  private def nativeSources(ss: Seq[Def.SettingsDefinition]) =
+    platformSources("native", ss, "jvm-native", "js-native")
 
   // a test binary commits a bytemap of a sixteenth of its maximum heap before
   // it runs, and Windows cannot overcommit; the maximum defaults to the memory
@@ -51,25 +59,48 @@ object Extensions {
   private def nativeHeap = Def
     .settings(Test / envVars += "GC_MAXIMUM_HEAP_SIZE" -> "512m")
 
+  /* IntelliJ folds the source roots that matrix cells share into one module,
+   * so the whole matrix compiles scala-2 and scala-3 together. Only IntelliJ's
+   * importer reads `ide-skip-project`, so these properties change what the IDE
+   * sees and never what sbt builds. */
+  private val ideSkipProject = SettingKey[Boolean]("ide-skip-project")
+
+  private val ideScala = {
+    val prop = sys.props.getOrElse("ide.scala", "").trim
+    if (prop.isEmpty) scala213 else prop
+  }
+
+  // the platforms to import besides the JVM, which the IDE always gets
+  private val idePlatforms = {
+    val prop = sys.props.getOrElse("ide.platform", "").trim
+    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet + "jvm"
+  }
+
+  private def ideSkip(platform: String) = Seq(ideSkipProject := {
+    val versions = Set(scalaBinaryVersion.value, scalaVersion.value)
+    !versions(ideScala) || idePlatforms.nonEmpty && !idePlatforms(platform)
+  })
+
   implicit class ProjectMatrixExtensions(private val self: ProjectMatrix)
       extends AnyVal {
 
     def crossJvm(ss: Def.SettingsDefinition*): ProjectMatrix = self
-      .jvmPlatform(ScalaVersions, jvmSources ++ ss.flatMap(_.settings))
+      .jvmPlatform(ScalaVersions, jvmSources(ss))
 
     def crossJs(ss: Def.SettingsDefinition*): ProjectMatrix = self
-      .jsPlatform(ScalaVersions, jsSources ++ ss.flatMap(_.settings))
+      .jsPlatform(ScalaVersions, jsSources(ss))
 
     def crossNative(ss: Def.SettingsDefinition*): ProjectMatrix = self
-      .nativePlatform(
-        ScalaVersions,
-        nativeSources ++ nativeHeap ++ ss.flatMap(_.settings),
-      )
+      .nativePlatform(ScalaVersions, nativeSources(ss) ++ nativeHeap)
+
+    // a JVM row for a project laid out the standard way, not as a crossProject
+    def crossJvmPlain: ProjectMatrix = self
+      .jvmPlatform(ScalaVersions, ideSkip("jvm"))
 
     // one row per Scala version, for rows that name their own dependencies
     def crossJvmRows(configure: String => Project => Project): ProjectMatrix =
       ScalaVersions.foldLeft(self) { (matrix, version) =>
-        val func = configure(version).andThen(_.settings(jvmSources))
+        val func = configure(version).andThen(_.settings(jvmSources(Nil)))
         matrix.jvmPlatform(Seq(version), Nil, func)
       }
 


### PR DESCRIPTION
The IDE imported every cell, and the result did not compile. Now it imports 2.13 on every platform: `-Dide.scala` picks the version and `-Dide.platform` picks the platforms besides the JVM.

`ide-skip-project` is IntelliJ's own key, so no plugin is needed. It reaches a row only through a `cross*` helper, which is why the typesafe and docs rows move to one.