### PR TITLE
build: name every cell and every version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - if: ${{ !cancelled() }}
-        run: sbt '++2.13; tests/testFull'
+        run: sbt test-jvm-2_13
       - if: ${{ !cancelled() }}
-        run: sbt '++2.13; docs/testFull'
+        run: sbt test-docs-2_13
       - if: ${{ !cancelled() }}
         run: ./bin/scalafmt --check
       - if: ${{ !cancelled() }}
@@ -41,7 +41,7 @@ jobs:
       - if: ${{ !cancelled() }}
         run: sbt mimaReportBinaryIssues
       - if: ${{ !cancelled() }}
-        run: sbt docs/docusaurusCreateSite
+        run: sbt docsJVM2_13/docusaurusCreateSite
 
   pr-all3-nonjvm213: # 2.13 on JS and Native, 3.x everywhere, 2.12 compiled
     name: All-3, nonJVM-213, 2.12 compile
@@ -53,13 +53,13 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - if: ${{ !cancelled() }}
-        run: sbt '++2.13; testsJS/testFull'
+        run: sbt test-js-2_13
       - if: ${{ !cancelled() }}
-        run: sbt '++2.13; testsNative/testFull'
+        run: sbt test-native-2_13
       - if: ${{ !cancelled() }}
-        run: sbt '++2.12; Test/compile'
+        run: sbt compile-2_12
       - if: ${{ !cancelled() }}
-        run: sbt '++3.x; testFull'
+        run: sbt test-3
 
   post-cross: # every Scala version, on both JDKs and both operating systems
     name: ${{ matrix.os }} jdk-${{ matrix.java }} tests
@@ -90,8 +90,8 @@ jobs:
       # one step per version: each is its own group in the log, and Windows
       # cannot commit the heaps for two versions' native binaries at once
       - if: ${{ !cancelled() && contains(matrix.versions, ' 2.13 ') }}
-        run: sbt '++2.13; testFull'
+        run: sbt test-2_13
       - if: ${{ !cancelled() && contains(matrix.versions, ' 2.12 ') }}
-        run: sbt '++2.12; testFull'
+        run: sbt test-2_12
       - if: ${{ !cancelled() && contains(matrix.versions, ' 3.x ') }}
-        run: sbt '++3.x; testFull'
+        run: sbt test-3

--- a/.github/workflows/release-website.yml
+++ b/.github/workflows/release-website.yml
@@ -21,6 +21,6 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Publish
         run: |
-          sbt docs/docusaurusPublishGhpages
+          sbt docsJVM2_13/docusaurusPublishGhpages
         env:
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,15 @@ Please refer to the
 contributing guidelines to learn more about how to report tickets and open pull
 requests.
 
+## sbt
+
+Every matrix cell carries its platform and its Scala version, so a command has
+to name one: `testsJVM2_13/testFull`, not `tests/testFull`. The build generates
+an alias per version for the sets CI runs, such as `test-jvm-2_13`, `test-2_13`
+and `compile-2_12`, so no workflow step spells out a cell id. `++` selects
+nothing: it switches the Scala version on the cells that accept it and leaves
+aggregation alone.
+
 ## IntelliJ
 
 IntelliJ imports the project for one Scala version, 2.13 by default,

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ addCommandAlias("scalafixCheckAll", scalafixOn("--check"))
 
 addCommandAlias(
   "native-image",
-  "; tests/graalvm-native-image:packageBin ; taskready",
+  s"; ${tests.jvm(scala213).id}/graalvm-native-image:packageBin ; taskready",
 )
 
 commands += Command.command("taskready") { s =>
@@ -136,7 +136,7 @@ def pprintSettings = Def.settings(
   },
 )
 
-lazy val pprint = projectMatrix.in(file("metaconfig-pprint"))
+lazy val pprint = projectMatrix.in(file("metaconfig-pprint")).defaultAxes()
   .settings(pprintSettings).crossJvm(jvmReleaseSettings).crossJs().crossNative()
 
 def coreSettings = Def.settings(
@@ -158,9 +158,9 @@ def coreJsSettings = Def.settings(
     (smorg %% "io" % "4.17.3").cross(CrossVersion.for3Use2_13),
 )
 
-lazy val core = projectMatrix.in(file("metaconfig-core")).settings(coreSettings)
-  .dependsOn(pprint).crossNative().crossJvm(jvmReleaseSettings)
-  .crossJs(coreJsSettings)
+lazy val core = projectMatrix.in(file("metaconfig-core")).defaultAxes()
+  .settings(coreSettings).dependsOn(pprint).crossNative()
+  .crossJvm(jvmReleaseSettings).crossJs(coreJsSettings)
 
 def cliSettings = Def.settings(
   sharedSettings,
@@ -169,8 +169,9 @@ def cliSettings = Def.settings(
   depPaiges,
 )
 
-lazy val cli = projectMatrix.in(file("metaconfig-cli")).settings(cliSettings)
-  .crossJvm(jvmReleaseSettings).crossNative().dependsOn(core)
+lazy val cli = projectMatrix.in(file("metaconfig-cli")).defaultAxes()
+  .settings(cliSettings).crossJvm(jvmReleaseSettings).crossNative()
+  .dependsOn(core)
 
 def typesafeSettings = Def.settings(
   sharedSettings,
@@ -182,7 +183,7 @@ def typesafeSettings = Def.settings(
 )
 
 lazy val typesafe = projectMatrix.in(file("metaconfig-typesafe-config"))
-  .settings(typesafeSettings).crossJvmPlain.dependsOn(core)
+  .defaultAxes().settings(typesafeSettings).crossJvmPlain.dependsOn(core)
 
 def sconfigSettings = Def.settings(
   sharedSettings,
@@ -198,7 +199,7 @@ def sconfigSettings = Def.settings(
 def sjavatime = Def
   .settings(libraryDependencies += "org.ekrich" %% "sjavatime" % "1.5.0")
 
-lazy val sconfig = projectMatrix.in(file("metaconfig-sconfig"))
+lazy val sconfig = projectMatrix.in(file("metaconfig-sconfig")).defaultAxes()
   .settings(sconfigSettings).crossJvm(jvmReleaseSettings)
   .crossJs(sharedJSSettings, sjavatime).crossNative(sjavatime).dependsOn(core)
 
@@ -240,7 +241,7 @@ def testsJvmSettings = Def.settings(
   },
 )
 
-lazy val tests = projectMatrix.in(file("metaconfig-tests"))
+lazy val tests = projectMatrix.in(file("metaconfig-tests")).defaultAxes()
   .settings(testsSettings).crossJs(sharedJSSettings).crossNative()
   .crossJvmRows(v =>
     _.enablePlugins(GraalVMNativeImagePlugin).settings(testsJvmSettings)
@@ -265,6 +266,10 @@ def docsSettings = Def.settings(
   evictionErrorLevel := Level.Warn,
 )
 
-lazy val docs = projectMatrix.in(file("metaconfig-docs")).settings(docsSettings)
-  .crossJvmPlain.dependsOn(core, typesafe, sconfig)
+lazy val docs = projectMatrix.in(file("metaconfig-docs")).defaultAxes()
+  .settings(docsSettings).crossJvmPlain.dependsOn(core, typesafe, sconfig)
   .enablePlugins(DocusaurusPlugin).disablePlugins(MimaPlugin)
+
+testAliases(ScalaVersions, tests)
+crossAliases(ScalaVersions, pprint, core, cli, typesafe, sconfig, tests, docs)
+addCommandAlias("test-docs-2_13", s"${docs.jvm(scala213).id}/testFull")

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -81,6 +81,36 @@ object Extensions {
     !versions(ideScala) || idePlatforms.nonEmpty && !idePlatforms(platform)
   })
 
+  // sbt runs a `;`-separated list; the leading separator is required
+  def tasks(ts: Iterable[String]): String = ts.mkString("; ", "; ", "")
+
+  private def idSuffix(v: String) = VirtualAxis.scalaABIVersion(v).idSuffix
+
+  // `++<version>` selects no row, so every version gets its own alias. Cell ids
+  // are generated, so the names are taken from them rather than spelled out.
+  def testAliases(versions: Seq[String], matrices: ProjectMatrix*) = versions
+    .flatMap { v =>
+      def alias(name: String, f: ProjectMatrix => ProjectFinder) =
+        addCommandAlias(
+          s"test-$name-${idSuffix(v)}",
+          tasks(matrices.map(m => s"${f(m)(v).id}/testFull")),
+        )
+      alias("jvm", _.jvm) ++ alias("js", _.js) ++ alias("native", _.native)
+    }
+
+  // every row of a version, whatever its platform: what a cross-build job runs
+  def crossAliases(versions: Seq[String], matrices: ProjectMatrix*) = versions
+    .flatMap { v =>
+      val rows = matrices.flatMap(_.allProjects().collect {
+        case (p, axes) if axes.contains(VirtualAxis.scalaABIVersion(v)) => p.id
+      })
+      def alias(name: String, task: String) = addCommandAlias(
+        s"$name-${idSuffix(v)}",
+        tasks(rows.map(id => s"$id/$task")),
+      )
+      alias("test", "testFull") ++ alias("compile", "Test/compile")
+    }
+
   implicit class ProjectMatrixExtensions(private val self: ProjectMatrix)
       extends AnyVal {
 


### PR DESCRIPTION
A matrix with no `defaultAxes` unsuffixes one row, and sbt's own default chose which. `tests` was the Scala 3 cell, so `++2.13; tests/testFull` tested 3 while claiming 2.13. `++` does not help either: it switches the Scala version only on cells that accept it and leaves aggregation alone, so `++2.13; testFull` ran the whole matrix and the three post-cross steps repeated one another.

Now every cell carries its platform and its version, and the aliases CI calls are generated from the rows, as in scalafmt and scalameta, so no workflow step spells out a cell id and no list here goes stale. `native-image` built the Scala 3 cell by the same accident and now names 2.13.