### PR TITLE
scala3 prep: use -Werror, not -Xfatal-warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val sharedSettings = Def.settings(
     else "-Ywarn-unused-import"
   },
   scalacOptions += "-deprecation",
-  scalacOptions += "-Xfatal-warnings",
+  scalacOptions += "-Werror",
   scalacOptions ++= {
     if (isScala213.value) "-Wconf:cat=deprecation:is" :: Nil
     else if (isScala3.value) "-Wconf:cat=deprecation:silent" :: Nil


### PR DESCRIPTION
Scala 3.9 makes -Xfatal-warnings a deprecated alias, and the deprecation warning is itself fatal under the option. A build that passes it cannot compile under 3.9 at all. Now the build passes -Werror, which 2.12.21, 2.13.18 and 3.3.8 also accept.