### PR TITLE
scala3 prep: make three context bounds explicit

### DIFF
--- a/metaconfig-cli/shared/src/main/scala/metaconfig/cli/CliApp.scala
+++ b/metaconfig-cli/shared/src/main/scala/metaconfig/cli/CliApp.scala
@@ -34,7 +34,7 @@ case class CliApp(
           .find(_.matchesName(subcommand)) match {
           case Some(command) =>
             val configured: Configured[command.Value] = Conf
-              .parseCliArgs[command.Value](tail)(command.settings)
+              .parseCliArgs[command.Value](tail)(using command.settings)
               .andThen(_.as[command.Value](command.decoder))
             configured.fold { error =>
               error.all.foreach(message => app.error(message))

--- a/metaconfig-core/shared/src/main/scala/metaconfig/generic/Settings.scala
+++ b/metaconfig-core/shared/src/main/scala/metaconfig/generic/Settings.scala
@@ -65,7 +65,7 @@ final class Settings[T](
   def toCliHelp(default: T)(implicit ev: ConfEncoder[T]): String =
     toCliHelp(default, 80)
   def toCliHelp(default: T, width: Int)(implicit ev: ConfEncoder[T]): String =
-    Cli.help[T](default)(ev, this).renderTrim(width)
+    Cli.help[T](default)(using ev, this).renderTrim(width)
 
   def cliDescription: Option[Doc] = annotations.collectFirst {
     case DescriptionDoc(doc) => doc

--- a/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/EchoOptionsSuite.scala
+++ b/metaconfig-tests/jvm/src/test/scala/metaconfig/cli/EchoOptionsSuite.scala
@@ -7,7 +7,8 @@ class EchoOptionsSuite extends munit.FunSuite {
   def checkError(name: String, input: String, expectedError: String)(implicit
       loc: munit.Location,
   ): Unit = test(name) {
-    val parsed = Hocon.parseFilename("hello.conf", input)(EchoOptions.decoder)
+    val parsed = Hocon
+      .parseFilename("hello.conf", input)(using EchoOptions.decoder)
     assert(clue(parsed).isNotOk)(munit.Location.generate)
     assertNoDiff(parsed.getError.toString, expectedError)
 

--- a/metaconfig-tests/shared/src/test/scala/metaconfig/SettingsSuite.scala
+++ b/metaconfig-tests/shared/src/test/scala/metaconfig/SettingsSuite.scala
@@ -68,6 +68,16 @@ class SettingsSuite extends munit.FunSuite {
     )
   }
 
+  test("toCliHelp") {
+    assertNoDiff(
+      Settings[Nested2].toCliHelp(Nested2(), 60),
+      """|--a: String = "nested2"
+         |--b: OneParam = {"param": 82}
+         |--c: Map[String, OneParam] = {"k2": {"param": 2}}
+         |""".stripMargin,
+    )
+  }
+
   test("overlapping names") {
     def asList(x: Surface[_]) = x.fields.flatten.map(new Setting(_))
     val foo = asList(generic.deriveSurface[Foo])


### PR DESCRIPTION
Each method has a caller that passes the implicit as a positional argument. Scala 3.9 maps a context bound to a context parameter, and a positional argument cannot fill one, so those calls stop resolving there.