### PR TITLE
Extensions: narrow the import with bspEnabled

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,23 +16,32 @@ aggregation alone.
 
 ## IntelliJ
 
-IntelliJ imports the project for one Scala version, 2.13 by default,
-because it cannot import the whole matrix: it puts the sources that
-several rows use into one module, and then compiles the Scala 2 and the
-Scala 3 copies of `metaconfig.generic` and `metaconfig.pprint` together.
-To change what it imports, set the properties below under
-`Settings -> Build, Execution, Deployment -> Build Tools -> sbt -> VM parameters`
-and reload the sbt project:
+sbt builds each project of this build once per Scala version and platform.
+Several of those rows use the same source directories. Two system properties
+control which rows an IDE imports: the build sets `bspEnabled := false` on the
+other rows, and sbt then leaves them out of the BSP workspace.
 
-- `-Dide.scala=X`: sbt keeps only the rows for Scala version `X`, such as
-  `2.12`, `2.13` or `3`. Without it, IntelliJ gets 2.13 and every other tool
-  gets every version.
-- `-Dide.platform=Y`: sbt keeps only the rows for the platforms in `Y`, a
-  comma-separated list such as `jvm,js`. Without it sbt keeps every platform.
+- `-Dide.scala=X` — sbt keeps only the rows for Scala version `X`.
+  - matches full or binary version
+  - if unspecified or empty: keep all scala versions
+    - IntelliJ only: will be forced to `2.13`; see below why IntelliJ can't
+      load multiple versions.
+- `-Dide.platform=Y` — sbt keeps only the rows for the platforms in `Y`, a
+  comma-separated list.
+  - matches `jvm`, `js`, or `native`
+  - if unspecified or empty: keep every platform
 
-The build sets `bspEnabled := false` on the rows it drops. An sbt server that
-is already running uses the properties from its own command line, so run `sbt
-shutdown` before you test a change from the shell.
+IntelliJ cannot import the whole matrix. It puts the sources that several rows
+use into one module, and then compiles the Scala 2 and the Scala 3 copies of
+`metaconfig.generic` and `metaconfig.pprint` together. It starts sbt with
+`-Didea.managed=true`. If you do not set `-Dide.scala`, that property selects
+2.13. To choose another version, add `-Dide.scala=X` under
+`Settings -> Build, Execution, Deployment -> Build Tools -> sbt -> VM parameters`,
+then reload the sbt project.
+
+An sbt server uses the system properties from its own command line. It ignores
+a property that you pass to a later command. Run `sbt shutdown` before you test
+a change to these properties from the shell.
 
 ## Website
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ and `compile-2_12`, so no workflow step spells out a cell id. `++` selects
 nothing: it switches the Scala version on the cells that accept it and leaves
 aggregation alone.
 
-## IntelliJ
+## Narrowing what an IDE imports
 
 sbt builds each project of this build once per Scala version and platform.
 Several of those rows use the same source directories. Two system properties

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,18 +17,22 @@ aggregation alone.
 ## IntelliJ
 
 IntelliJ imports the project for one Scala version, 2.13 by default,
-because it puts the sources that the matrix cells share into a single
-module: importing every cell compiles the Scala 2 and the Scala 3 copies
-of `metaconfig.generic` and `metaconfig.pprint` together. If you need to
-modify the defaults, set the properties below under
+because it cannot import the whole matrix: it puts the sources that
+several rows use into one module, and then compiles the Scala 2 and the
+Scala 3 copies of `metaconfig.generic` and `metaconfig.pprint` together.
+To change what it imports, set the properties below under
 `Settings -> Build, Execution, Deployment -> Build Tools -> sbt -> VM parameters`
 and reload the sbt project:
 
-- `-Dide.scala=X`: imports Scala version `X` instead (could be `2.12`, `2.13`,
-  or `3`). `-Dide.scala=`, with no value, imports the default.
-- `-Dide.platform=Y`: if `Y` is empty, imports all platforms; otherwise, `Y` is
-  a comma-separated list of platforms to import, and `jvm` is implied, whether
-  or not it is explicitly listed, while `js` and `native` are optional.
+- `-Dide.scala=X`: sbt keeps only the rows for Scala version `X`, such as
+  `2.12`, `2.13` or `3`. Without it, IntelliJ gets 2.13 and every other tool
+  gets every version.
+- `-Dide.platform=Y`: sbt keeps only the rows for the platforms in `Y`, a
+  comma-separated list such as `jvm,js`. Without it sbt keeps every platform.
+
+The build sets `bspEnabled := false` on the rows it drops. An sbt server that
+is already running uses the properties from its own command line, so run `sbt
+shutdown` before you test a change from the shell.
 
 ## Website
 

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -44,7 +44,7 @@ object Extensions {
       ss: Seq[Def.SettingsDefinition],
       platforms: String*,
   ) = unmanagedSources("shared" +: platform +: platforms *) ++
-    ideSkip(platform) ++ ss.flatMap(_.settings)
+    ideImport(platform) ++ ss.flatMap(_.settings)
 
   private def jvmSources(ss: Seq[Def.SettingsDefinition]) =
     platformSources("jvm", ss, "js-jvm", "jvm-native")
@@ -59,26 +59,27 @@ object Extensions {
   private def nativeHeap = Def
     .settings(Test / envVars += "GC_MAXIMUM_HEAP_SIZE" -> "512m")
 
-  /* IntelliJ folds the source roots that matrix cells share into one module,
-   * so the whole matrix compiles scala-2 and scala-3 together. Only IntelliJ's
-   * importer reads `ide-skip-project`, so these properties change what the IDE
-   * sees and never what sbt builds. */
-  private val ideSkipProject = SettingKey[Boolean]("ide-skip-project")
-
+  /* `bspEnabled := false` leaves a row out of the BSP workspace, so an IDE does
+   * not import it. IntelliJ can't load multiple versions, though, so force 2.13
+   * if `ide.scala` is absent. */
   private val ideScala = {
     val prop = sys.props.getOrElse("ide.scala", "").trim
-    if (prop.isEmpty) scala213 else prop
+    if (prop.nonEmpty) Some(prop)
+    // IntelliJ starts sbt with `idea.managed`
+    else if (sys.props.contains("idea.managed")) Some(scala213)
+    else None
   }
 
-  // the platforms to import besides the JVM, which the IDE always gets
+  // an empty set is no filter, so every platform
   private val idePlatforms = {
     val prop = sys.props.getOrElse("ide.platform", "").trim
-    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet + "jvm"
+    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet
   }
 
-  private def ideSkip(platform: String) = Seq(ideSkipProject := {
+  private def ideImport(platform: String) = Seq(bspEnabled := ! {
     val versions = Set(scalaBinaryVersion.value, scalaVersion.value)
-    !versions(ideScala) || idePlatforms.nonEmpty && !idePlatforms(platform)
+    ideScala.exists(!versions(_)) ||
+    idePlatforms.nonEmpty && !idePlatforms(platform)
   })
 
   // sbt runs a `;`-separated list; the leading separator is required
@@ -125,7 +126,7 @@ object Extensions {
 
     // a JVM row for a project laid out the standard way, not as a crossProject
     def crossJvmPlain: ProjectMatrix = self
-      .jvmPlatform(ScalaVersions, ideSkip("jvm"))
+      .jvmPlatform(ScalaVersions, ideImport("jvm"))
 
     // one row per Scala version, for rows that name their own dependencies
     def crossJvmRows(configure: String => Project => Project): ProjectMatrix =


### PR DESCRIPTION
`ide-skip-project` is IntelliJ's own key, and the filter picked 2.13 whether or not anyone asked for it, so Metals and a command-line `sbt` saw a narrowed build they never asked to narrow.

sbt owns `bspEnabled`, so the build sets that instead. It picks a Scala version only when `-Dide.scala` is set, or when IntelliJ starts sbt with `-Didea.managed=true`. Everything else keeps every row.

`-Dide.platform` no longer adds `jvm` to the list it is given, so `-Dide.platform=js` imports the Scala.js rows alone.

*- Claude (on behalf of Albert)*
